### PR TITLE
Add gcovr config file to exclude test code in coverage reports

### DIFF
--- a/gcovr.cfg
+++ b/gcovr.cfg
@@ -1,0 +1,2 @@
+# Exclude test code itself from coverage reports
+exclude = .*/test/.*


### PR DESCRIPTION
It just clutters the reports with largely unnecessary information. If we want
to clean up test code we can run it manually without the config file from
time to time.