### PR TITLE
Add Duration and Instant classes

### DIFF
--- a/src/engine/core/test/meson.build
+++ b/src/engine/core/test/meson.build
@@ -1,5 +1,5 @@
 t = executable(
-  'coretest',
+  'core_test',
   ['TestBitmask.cc', 'TestGrid.cc', 'TestPtr.cc'],
   dependencies : gtest,
   include_directories : engine)

--- a/src/engine/meson.build
+++ b/src/engine/meson.build
@@ -1,3 +1,4 @@
 engine = include_directories('.')
 
 subdir('core')
+subdir('time')

--- a/src/engine/time/Duration.hh
+++ b/src/engine/time/Duration.hh
@@ -1,0 +1,310 @@
+#pragma once
+
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <limits>
+#include <type_traits>
+
+namespace freeisle::time {
+
+/**
+ * Duration represents the duration of time between two time instants
+ * (or points). It represents the duration as the number of microseconds
+ * between the two instants.
+ *
+ * A duration can be negative. Valid representions range between
+ * -UINT64_MAX..UINT64_MAX. When doing arithmetics with durations,
+ * values and the result would overflow, it is instead clamped to lie
+ * within the valid range.
+ */
+class Duration {
+public:
+  /**
+   * The default constructor creates a duration of 0 microseconds.
+   */
+  Duration() : us(0) {}
+
+  /**
+   * Construct a duration from a specified number of seconds.
+   */
+  template <typename T> static Duration sec(T duration_s) {
+    return construct<T, 1000000>(duration_s);
+  }
+
+  /**
+   * Construct a duration from a specified number of milliseconds.
+   */
+  template <typename T> static Duration msec(T duration_ms) {
+    return construct<T, 1000>(duration_ms);
+  }
+
+  /**
+   * Construct a duration from a specified number of microseconds.
+   */
+  template <typename T> static Duration usec(T duration_us) {
+    return construct<T, 1>(duration_us);
+  }
+
+  /**
+   * Return the number of seconds represented by this duration.
+   */
+  template <typename T> T sec() const { return deconstruct<T, 1000000>(); }
+
+  /**
+   * Return the number of milliseconds represented by this duration.
+   */
+  template <typename T> T msec() const { return deconstruct<T, 1000>(); }
+
+  /**
+   * Return the number of microseconds represented by this duration.
+   */
+  template <typename T> T usec() const { return deconstruct<T, 1>(); }
+
+  Duration operator-() const { return Duration(-us); }
+
+  Duration &operator+=(Duration other) {
+    if (other.us < 0) {
+      return *this -= (-other);
+    }
+
+    if (us > max - other.us) {
+      us = max;
+    } else {
+      us += other.us;
+    }
+
+    return *this;
+  }
+
+  Duration &operator-=(Duration other) {
+    if (other.us < 0) {
+      return *this += (-other);
+    }
+
+    if (us < min + other.us) {
+      us = min;
+    } else {
+      us -= other.us;
+    }
+
+    return *this;
+  }
+
+  template <typename T> Duration &operator*=(const T &rhs) {
+    if (rhs == T(0)) {
+      us = 0;
+      return *this;
+    }
+
+    if (std::abs(rhs) < T(1)) {
+      // T must be floating point
+      return *this /= (T(1) / rhs);
+    }
+
+    if (rhs > T(0)) {
+      if (us > static_cast<int64_t>(max / rhs)) {
+        us = max;
+      } else if (us < static_cast<int64_t>(min / rhs)) {
+        us = min;
+      } else {
+        us *= rhs;
+      }
+    } else {
+      if (us > static_cast<int64_t>(max / -rhs)) {
+        us = min;
+      } else if (us < static_cast<int64_t>(min / -rhs)) {
+        us = max;
+      } else {
+        us *= rhs;
+      }
+    }
+
+    return *this;
+  }
+
+  template <typename T> Duration &operator/=(const T &rhs) {
+    assert(rhs != T(0));
+
+    if (std::abs(rhs) < T(1)) {
+      // T must be floating point
+      *this *= (T(1) / rhs);
+      return *this;
+    }
+
+    us /= rhs;
+    return *this;
+  }
+
+  bool operator==(Duration rhs) const { return us == rhs.us; }
+
+  bool operator<(Duration rhs) const { return us < rhs.us; }
+
+  bool operator>(Duration rhs) const { return us > rhs.us; }
+
+  bool operator<=(Duration rhs) const { return us <= rhs.us; }
+
+  bool operator>=(Duration rhs) const { return us >= rhs.us; }
+
+private:
+  Duration(int64_t us) : us(us) {}
+
+  template <typename T, int64_t Frac,
+            typename std::enable_if<std::is_floating_point<T>::value,
+                                    int64_t>::type = 0>
+  static Duration construct(T duration) {
+    constexpr T max_as_t = static_cast<T>(max / Frac);
+    constexpr T min_as_t = static_cast<T>(min / Frac);
+
+    if (duration > max_as_t) {
+      return Duration(max);
+    } else if (duration < min_as_t) {
+      return Duration(min);
+    }
+
+    return Duration(static_cast<int64_t>(std::round(duration * Frac)));
+  }
+
+  template <typename T, int64_t Frac,
+            typename std::enable_if<std::is_integral<T>::value &&
+                                        std::is_unsigned<T>::value,
+                                    int64_t>::type = 0>
+  static Duration construct(T duration) {
+    if (sizeof(T) >= sizeof(int64_t)) {
+      constexpr T max_as_t = static_cast<T>(max / Frac);
+      if (duration > max_as_t) {
+        return Duration(max);
+      }
+      return Duration(static_cast<int64_t>(duration) * Frac);
+    } else {
+      if (static_cast<int64_t>(duration) > max / Frac) {
+        return Duration(max);
+      }
+      return Duration(static_cast<int64_t>(duration) * Frac);
+    }
+  }
+
+  template <typename T, int64_t Frac,
+            typename std::enable_if<std::is_integral<T>::value &&
+                                        std::is_signed<T>::value,
+                                    int64_t>::type = 0>
+  static Duration construct(T duration) {
+    if (sizeof(T) > sizeof(int64_t)) {
+      constexpr T max_as_t = static_cast<T>(max / Frac);
+      constexpr T min_as_t = static_cast<T>(min / Frac);
+
+      if (duration > max_as_t) {
+        return Duration(max);
+      } else if (duration < min_as_t) {
+        return Duration(max);
+      }
+
+      return Duration(static_cast<int64_t>(duration) * Frac);
+    } else {
+      if (static_cast<int64_t>(duration) > max / Frac) {
+        return Duration(max);
+      } else if (static_cast<int64_t>(duration) < min / Frac) {
+        return Duration(min);
+      }
+
+      return Duration(static_cast<int64_t>(duration) * Frac);
+    }
+  }
+
+  template <typename T, int64_t Frac,
+            typename std::enable_if<std::is_floating_point<T>::value,
+                                    int64_t>::type = 0>
+  T deconstruct() const {
+    return T(us / Frac) + T(us % Frac) / T(Frac);
+  }
+
+  template <typename T, int64_t Frac,
+            typename std::enable_if<std::is_integral<T>::value &&
+                                        std::is_unsigned<T>::value,
+                                    int64_t>::type = 0>
+  T deconstruct() const {
+    if (us < 0) {
+      return T(0);
+    }
+
+    constexpr T max_t = std::numeric_limits<T>::max();
+    if (sizeof(T) < sizeof(us)) {
+      // might not fit
+      if (us / Frac > static_cast<int64_t>(max_t)) {
+        return max_t;
+      }
+    }
+
+    T t(us / Frac);
+
+    if (t < max_t && us % Frac > (Frac - 1) / 2) {
+      ++t;
+    }
+
+    return t;
+  }
+
+  template <typename T, int64_t Frac,
+            typename std::enable_if<std::is_integral<T>::value &&
+                                        std::is_signed<T>::value,
+                                    int64_t>::type = 0>
+  T deconstruct() const {
+    constexpr T max_t = std::numeric_limits<T>::max();
+    constexpr T min_t = -max_t;
+
+    if (sizeof(T) < sizeof(us)) {
+      if (us / Frac > static_cast<int64_t>(max_t)) {
+        return max_t;
+      } else if (us / Frac < static_cast<int64_t>(min_t)) {
+        return min_t;
+      }
+    }
+
+    T t(us / Frac);
+
+    if (t < max_t && us > 0 && us % Frac > (Frac - 1) / 2) {
+      ++t;
+    }
+
+    if (t > min_t && us < 0 && us % Frac < -(Frac - 1) / 2) {
+      --t;
+    }
+
+    return t;
+  }
+
+  int64_t us;
+
+  /**
+   * Maximum number of microseconds we can represent.
+   */
+  static constexpr int64_t max = std::numeric_limits<int64_t>::max();
+
+  /**
+   * Minimum number of microseconds we can represent. Note that this is
+   * defined differently from std::numeric_limits<int64_t>::min(), mostly
+   * because it makes all the bounds checks symmetric.
+   * It also reserves one value to represent an invalid duration, although
+   * it is not used as such yet.
+   */
+  static constexpr int64_t min = -std::numeric_limits<int64_t>::max();
+};
+
+inline Duration operator+(Duration lhs, Duration rhs) { return lhs += rhs; }
+
+inline Duration operator-(Duration lhs, Duration rhs) { return lhs -= rhs; }
+
+template <typename T> inline Duration operator*(Duration lhs, T rhs) {
+  return lhs *= rhs;
+}
+
+template <typename T> inline Duration operator*(T lhs, Duration rhs) {
+  return rhs *= lhs;
+}
+
+template <typename T> inline Duration operator/(Duration lhs, T rhs) {
+  return lhs /= rhs;
+}
+
+} // namespace freeisle::time

--- a/src/engine/time/Instant.cc
+++ b/src/engine/time/Instant.cc
@@ -1,0 +1,104 @@
+#include "time/Instant.hh"
+
+#include <ctime>
+
+namespace freeisle::time {
+
+Instant Instant::unixSec(int64_t timestamp) {
+  return Instant(Duration::sec(timestamp));
+}
+
+Instant Instant::unixMsec(int64_t timestamp_ms) {
+  return Instant(Duration::msec(timestamp_ms));
+}
+
+Instant Instant::unixUsec(int64_t timestamp_us) {
+  return Instant(Duration::usec(timestamp_us));
+}
+
+Instant Instant::gregorian(const Gregorian &gregorian) {
+  // There is no strict reason for this restriction, but it
+  // seems reasonable, and should protect us from timegm
+  // ever returning -1 and the result overflowing
+  // or underflowing.
+  assert(gregorian.year >= 0);
+  assert(gregorian.year <= 9999);
+  assert(gregorian.month >= 1);
+  assert(gregorian.month <= 12);
+
+  struct tm tm {};
+  tm.tm_year = gregorian.year - 1900;
+  tm.tm_mon = gregorian.month - 1;
+  tm.tm_mday = gregorian.day;
+  tm.tm_hour = gregorian.hour;
+  tm.tm_min = gregorian.minute;
+  tm.tm_sec = gregorian.second;
+
+  const time_t result = timegm(&tm);
+  assert(result != static_cast<time_t>(-1));
+
+  int64_t result64 = static_cast<int64_t>(result);
+  assert(result64 < std::numeric_limits<int64_t>::max() / 1000000);
+  assert(result64 > std::numeric_limits<int64_t>::min() / 1000000);
+
+  int64_t result64_usec = result64 * 1000000;
+  assert(result64 < 0 || std::numeric_limits<int64_t>::max() - result64 >=
+                             static_cast<int64_t>(gregorian.microsecond));
+
+  return Instant(Duration::usec(result64_usec +
+                                static_cast<int64_t>(gregorian.microsecond)));
+}
+
+Instant Instant::gregorian(int32_t year, uint32_t month, uint32_t day,
+                           uint32_t hour, uint32_t minute, uint32_t second,
+                           uint32_t microsecond) {
+  return gregorian(Gregorian{
+      .year = year,
+      .month = month,
+      .day = day,
+      .hour = hour,
+      .minute = minute,
+      .second = second,
+      .microsecond = microsecond,
+  });
+}
+
+int64_t Instant::unixSec() const { return val.sec<int64_t>(); }
+
+int64_t Instant::unixMsec() const { return val.msec<int64_t>(); }
+
+int64_t Instant::unixUsec() const { return val.usec<int64_t>(); }
+
+Instant::Gregorian Instant::break_down() const {
+  struct tm tm;
+
+  int64_t val_usec = val.usec<int64_t>();
+  time_t val_t = val_usec / 1000000;
+
+  struct tm *res = gmtime_r(&val_t, &tm);
+  assert(res != nullptr);
+
+  return Gregorian{
+      .year = static_cast<int32_t>(tm.tm_year) + 1900,
+      .month = static_cast<uint32_t>(tm.tm_mon + 1),
+      .day = static_cast<uint32_t>(tm.tm_mday),
+      .hour = static_cast<uint32_t>(tm.tm_hour),
+      .minute = static_cast<uint32_t>(tm.tm_min),
+      .second = static_cast<uint32_t>(tm.tm_sec),
+      .microsecond = static_cast<uint32_t>(val_usec % 1000000),
+  };
+}
+
+Duration Instant::operator-(Instant rhs) const { return val - rhs.val; }
+
+Instant &Instant::operator+=(Duration rhs) {
+  val += rhs;
+  return *this;
+}
+
+Instant &Instant::operator-=(Duration rhs) {
+  val -= rhs;
+  return *this;
+}
+
+} // namespace freeisle::time

--- a/src/engine/time/Instant.hh
+++ b/src/engine/time/Instant.hh
@@ -1,0 +1,142 @@
+#pragma once
+
+#include "time/Duration.hh"
+
+#include <cstdint>
+
+namespace freeisle::time {
+
+/**
+ * An instant in time, represented by a duration since the Unix epoch,
+ * with microsecond precision. Does not handle leap seconds.
+ */
+class Instant {
+public:
+  /**
+   * An instant broken down to the Gregorian calendar. The time portion
+   * represents UTC time.
+   */
+  struct Gregorian {
+    /**
+     * Calendar year.
+     */
+    int32_t year;
+
+    /**
+     * Month of the year, a numerical value between 1 and 12.
+     */
+    uint32_t month;
+
+    /**
+     * Day of the month, a numerical value between 1 and 31.
+     */
+    uint32_t day;
+
+    /**
+     * Hour within a day, a numerical value between 0 and 23.
+     */
+    uint32_t hour;
+
+    /**
+     * Minute within the hour, a numerical value between 0 and 59.
+     */
+    uint32_t minute;
+
+    /**
+     * Second within the minute, a numerical value between 0 and 60.
+     */
+    uint32_t second;
+
+    /**
+     * Microsecond within the second, a numerical value between 0 and
+     * 999999.
+     */
+    uint32_t microsecond;
+  };
+
+  /**
+   * A default-constructed instant refers to the origin of the UNIX epoch,
+   * 1970-01-01 00:00:00.000000.
+   */
+  Instant() = default;
+
+  /**
+   * Create an instant from a unix timestamp in seconds.
+   */
+  static Instant unixSec(int64_t timestamp);
+
+  /**
+   * Create an instant from a unix timestamp in milliseconds.
+   */
+  static Instant unixMsec(int64_t timestamp_ms);
+
+  /**
+   * Create an instant from a unix timestamp in microseconds.
+   */
+  static Instant unixUsec(int64_t timestamp_us);
+
+  /**
+   * Construct an instant from a Gregorian representation.
+   * The year must be between 0 and 9999, and all fields
+   * of the Gregorian structure must be populated correctly.
+   */
+  static Instant gregorian(const Gregorian &gregorian);
+
+  /**
+   * Construct an instant from a Gregorian representation,
+   * with the individual components as separate arguments.
+   */
+  static Instant gregorian(int32_t year, uint32_t month, uint32_t day,
+                           uint32_t hour = 0, uint32_t minute = 0,
+                           uint32_t second = 0, uint32_t microsecond = 0);
+
+  /**
+   * Returns the UNIX timestamp represented by this instant, in seconds.
+   * Fractional seconds are rounded toward the nearest second.
+   */
+  int64_t unixSec() const;
+
+  /**
+   * Returns the UNIX timestamp represented by this instant, in milliseconds.
+   * Fractional milliseconds are rounded toward the nearest millisecond.
+   */
+  int64_t unixMsec() const;
+
+  /**
+   * Returns the UNIX timestamp represented by this instant, in microseconds.
+   */
+  int64_t unixUsec() const;
+
+  /**
+   * Break down the instant into the components of the
+   * Gregorian calendar.
+   */
+  Gregorian break_down() const;
+
+  Duration operator-(Instant rhs) const;
+  Instant &operator+=(Duration rhs);
+  Instant &operator-=(Duration rhs);
+
+  bool operator==(Instant rhs) const { return val == rhs.val; }
+
+  bool operator!=(Instant rhs) const { return val == rhs.val; }
+
+  bool operator<(Instant rhs) const { return val < rhs.val; }
+
+  bool operator>(Instant rhs) const { return val > rhs.val; }
+
+  bool operator<=(Instant rhs) const { return val <= rhs.val; }
+
+  bool operator>=(Instant rhs) const { return val >= rhs.val; }
+
+private:
+  explicit Instant(Duration d) : val(d) {}
+
+  Duration val;
+};
+
+inline Instant operator+(Instant lhs, Duration rhs) { return lhs += rhs; }
+
+inline Instant operator-(Instant lhs, Duration rhs) { return lhs -= rhs; }
+
+} // namespace freeisle::time

--- a/src/engine/time/meson.build
+++ b/src/engine/time/meson.build
@@ -1,0 +1,1 @@
+subdir('test')

--- a/src/engine/time/meson.build
+++ b/src/engine/time/meson.build
@@ -1,1 +1,6 @@
+time_lib = library(
+  'time',
+  ['Instant.cc'],
+  include_directories : engine)
+
 subdir('test')

--- a/src/engine/time/test/TestDuration.cc
+++ b/src/engine/time/test/TestDuration.cc
@@ -1,0 +1,435 @@
+#include "time/Duration.hh"
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+TEST(Duration, Default) {
+  freeisle::time::Duration duration;
+  EXPECT_EQ(duration.sec<int32_t>(), 0);
+  EXPECT_EQ(duration.sec<uint32_t>(), 0);
+  EXPECT_EQ(duration.sec<int64_t>(), 0);
+  EXPECT_EQ(duration.sec<uint64_t>(), 0);
+  EXPECT_EQ(duration.sec<float>(), 0.f);
+  EXPECT_EQ(duration.sec<double>(), 0.);
+
+  EXPECT_EQ(duration.msec<int32_t>(), 0);
+  EXPECT_EQ(duration.msec<uint32_t>(), 0);
+  EXPECT_EQ(duration.msec<int64_t>(), 0);
+  EXPECT_EQ(duration.msec<uint64_t>(), 0);
+  EXPECT_EQ(duration.msec<float>(), 0.f);
+  EXPECT_EQ(duration.msec<double>(), 0.);
+
+  EXPECT_EQ(duration.usec<int32_t>(), 0);
+  EXPECT_EQ(duration.usec<uint32_t>(), 0);
+  EXPECT_EQ(duration.usec<int64_t>(), 0);
+  EXPECT_EQ(duration.usec<uint64_t>(), 0);
+  EXPECT_EQ(duration.usec<float>(), 0.f);
+  EXPECT_EQ(duration.usec<double>(), 0.);
+}
+
+TEST(Duration, ConstructFromSecInt) {
+  freeisle::time::Duration duration = freeisle::time::Duration::sec(2);
+
+  EXPECT_EQ(duration.sec<int32_t>(), 2);
+  EXPECT_EQ(duration.sec<uint32_t>(), 2);
+  EXPECT_EQ(duration.sec<int64_t>(), 2);
+  EXPECT_EQ(duration.sec<uint64_t>(), 2);
+  EXPECT_EQ(duration.sec<float>(), 2.f);
+  EXPECT_EQ(duration.sec<double>(), 2.);
+
+  EXPECT_EQ(duration.msec<int32_t>(), 2000);
+  EXPECT_EQ(duration.msec<uint32_t>(), 2000);
+  EXPECT_EQ(duration.msec<int64_t>(), 2000);
+  EXPECT_EQ(duration.msec<uint64_t>(), 2000);
+  EXPECT_EQ(duration.msec<float>(), 2000.f);
+  EXPECT_EQ(duration.msec<double>(), 2000.);
+
+  EXPECT_EQ(duration.usec<int32_t>(), 2000000);
+  EXPECT_EQ(duration.usec<uint32_t>(), 2000000);
+  EXPECT_EQ(duration.usec<int64_t>(), 2000000);
+  EXPECT_EQ(duration.usec<uint64_t>(), 2000000);
+  EXPECT_EQ(duration.usec<float>(), 2000000.f);
+  EXPECT_EQ(duration.usec<double>(), 2000000.);
+}
+
+TEST(Duration, ConstructFromSecFloatRoundDown) {
+  freeisle::time::Duration duration = freeisle::time::Duration::sec(2.4f);
+
+  EXPECT_EQ(duration.sec<int32_t>(), 2);
+  EXPECT_EQ(duration.sec<uint32_t>(), 2);
+  EXPECT_EQ(duration.sec<int64_t>(), 2);
+  EXPECT_EQ(duration.sec<uint64_t>(), 2);
+  EXPECT_EQ(duration.sec<float>(), 2.4f);
+  EXPECT_EQ(duration.sec<double>(), 2.4);
+
+  EXPECT_EQ(duration.msec<int32_t>(), 2400);
+  EXPECT_EQ(duration.msec<uint32_t>(), 2400);
+  EXPECT_EQ(duration.msec<int64_t>(), 2400);
+  EXPECT_EQ(duration.msec<uint64_t>(), 2400);
+  EXPECT_EQ(duration.msec<float>(), 2400.f);
+  EXPECT_EQ(duration.msec<double>(), 2400.);
+
+  EXPECT_EQ(duration.usec<int32_t>(), 2400000);
+  EXPECT_EQ(duration.usec<uint32_t>(), 2400000);
+  EXPECT_EQ(duration.usec<int64_t>(), 2400000);
+  EXPECT_EQ(duration.usec<uint64_t>(), 2400000);
+  EXPECT_EQ(duration.usec<float>(), 2400000.f);
+  EXPECT_EQ(duration.usec<double>(), 2400000.);
+}
+
+TEST(Duration, ConstructFromSecFloatRoundUp) {
+  freeisle::time::Duration duration = freeisle::time::Duration::sec(2.6f);
+
+  EXPECT_EQ(duration.sec<int32_t>(), 3);
+  EXPECT_EQ(duration.sec<uint32_t>(), 3);
+  EXPECT_EQ(duration.sec<int64_t>(), 3);
+  EXPECT_EQ(duration.sec<uint64_t>(), 3);
+  EXPECT_EQ(duration.sec<float>(), 2.6f);
+  EXPECT_EQ(duration.sec<double>(), 2.6);
+
+  EXPECT_EQ(duration.msec<int32_t>(), 2600);
+  EXPECT_EQ(duration.msec<uint32_t>(), 2600);
+  EXPECT_EQ(duration.msec<int64_t>(), 2600);
+  EXPECT_EQ(duration.msec<uint64_t>(), 2600);
+  EXPECT_EQ(duration.msec<float>(), 2600.f);
+  EXPECT_EQ(duration.msec<double>(), 2600.);
+
+  EXPECT_EQ(duration.usec<int32_t>(), 2600000);
+  EXPECT_EQ(duration.usec<uint32_t>(), 2600000);
+  EXPECT_EQ(duration.usec<int64_t>(), 2600000);
+  EXPECT_EQ(duration.usec<uint64_t>(), 2600000);
+  EXPECT_EQ(duration.usec<float>(), 2600000.f);
+  EXPECT_EQ(duration.usec<double>(), 2600000.);
+}
+
+TEST(Duration, ConstructFromSecIntNegative) {
+  freeisle::time::Duration duration = freeisle::time::Duration::sec(-2);
+
+  EXPECT_EQ(duration.sec<int32_t>(), -2);
+  EXPECT_EQ(duration.sec<uint32_t>(), 0);
+  EXPECT_EQ(duration.sec<int64_t>(), -2);
+  EXPECT_EQ(duration.sec<uint64_t>(), 0);
+  EXPECT_EQ(duration.sec<float>(), -2.f);
+  EXPECT_EQ(duration.sec<double>(), -2.);
+
+  EXPECT_EQ(duration.msec<int32_t>(), -2000);
+  EXPECT_EQ(duration.msec<uint32_t>(), 0);
+  EXPECT_EQ(duration.msec<int64_t>(), -2000);
+  EXPECT_EQ(duration.msec<uint64_t>(), 0);
+  EXPECT_EQ(duration.msec<float>(), -2000.f);
+  EXPECT_EQ(duration.msec<double>(), -2000.);
+
+  EXPECT_EQ(duration.usec<int32_t>(), -2000000);
+  EXPECT_EQ(duration.usec<uint32_t>(), 0);
+  EXPECT_EQ(duration.usec<int64_t>(), -2000000);
+  EXPECT_EQ(duration.usec<uint64_t>(), 0);
+  EXPECT_EQ(duration.usec<float>(), -2000000.f);
+  EXPECT_EQ(duration.usec<double>(), -2000000.);
+}
+
+TEST(Duration, ConstructFromSecFloatRoundDownNegative) {
+  freeisle::time::Duration duration = freeisle::time::Duration::sec(-2.4f);
+
+  EXPECT_EQ(duration.sec<int32_t>(), -2);
+  EXPECT_EQ(duration.sec<uint32_t>(), 0);
+  EXPECT_EQ(duration.sec<int64_t>(), -2);
+  EXPECT_EQ(duration.sec<uint64_t>(), 0);
+  EXPECT_EQ(duration.sec<float>(), -2.4f);
+  EXPECT_EQ(duration.sec<double>(), -2.4);
+
+  EXPECT_EQ(duration.msec<int32_t>(), -2400);
+  EXPECT_EQ(duration.msec<uint32_t>(), 0);
+  EXPECT_EQ(duration.msec<int64_t>(), -2400);
+  EXPECT_EQ(duration.msec<uint64_t>(), 0);
+  EXPECT_EQ(duration.msec<float>(), -2400.f);
+  EXPECT_EQ(duration.msec<double>(), -2400.);
+
+  EXPECT_EQ(duration.usec<int32_t>(), -2400000);
+  EXPECT_EQ(duration.usec<uint32_t>(), 0);
+  EXPECT_EQ(duration.usec<int64_t>(), -2400000);
+  EXPECT_EQ(duration.usec<uint64_t>(), 0);
+  EXPECT_EQ(duration.usec<float>(), -2400000.f);
+  EXPECT_EQ(duration.usec<double>(), -2400000.);
+}
+
+TEST(Duration, ConstructFromSecFloatRoundUpNegative) {
+  freeisle::time::Duration duration = freeisle::time::Duration::sec(-2.6f);
+
+  EXPECT_EQ(duration.sec<int32_t>(), -3);
+  EXPECT_EQ(duration.sec<uint32_t>(), 0);
+  EXPECT_EQ(duration.sec<int64_t>(), -3);
+  EXPECT_EQ(duration.sec<uint64_t>(), 0);
+  EXPECT_EQ(duration.sec<float>(), -2.6f);
+  EXPECT_EQ(duration.sec<double>(), -2.6);
+
+  EXPECT_EQ(duration.msec<int32_t>(), -2600);
+  EXPECT_EQ(duration.msec<uint32_t>(), 0);
+  EXPECT_EQ(duration.msec<int64_t>(), -2600);
+  EXPECT_EQ(duration.msec<uint64_t>(), 0);
+  EXPECT_EQ(duration.msec<float>(), -2600.f);
+  EXPECT_EQ(duration.msec<double>(), -2600.);
+
+  EXPECT_EQ(duration.usec<int32_t>(), -2600000);
+  EXPECT_EQ(duration.usec<uint32_t>(), 0);
+  EXPECT_EQ(duration.usec<int64_t>(), -2600000);
+  EXPECT_EQ(duration.usec<uint64_t>(), 0);
+  EXPECT_EQ(duration.usec<float>(), -2600000.f);
+  EXPECT_EQ(duration.usec<double>(), -2600000.);
+}
+
+TEST(Duration, ConstructBig) {
+  const int64_t secs = 1000000000000;
+  const int64_t msecs = secs * 1000;
+  const int64_t usecs = msecs * 1000;
+
+  freeisle::time::Duration duration = freeisle::time::Duration::msec(msecs);
+
+  EXPECT_EQ(duration.sec<int32_t>(), std::numeric_limits<int32_t>::max());
+  EXPECT_EQ(duration.sec<uint32_t>(), std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(duration.sec<int64_t>(), secs);
+  EXPECT_EQ(duration.sec<uint64_t>(), secs);
+  EXPECT_EQ(duration.sec<float>(), secs);
+  EXPECT_EQ(duration.sec<double>(), secs);
+
+  EXPECT_EQ(duration.msec<int32_t>(), std::numeric_limits<int32_t>::max());
+  EXPECT_EQ(duration.msec<uint32_t>(), std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(duration.msec<int64_t>(), msecs);
+  EXPECT_EQ(duration.msec<uint64_t>(), msecs);
+  EXPECT_EQ(duration.msec<float>(), msecs);
+  EXPECT_EQ(duration.msec<double>(), msecs);
+
+  EXPECT_EQ(duration.usec<int32_t>(), std::numeric_limits<int32_t>::max());
+  EXPECT_EQ(duration.usec<uint32_t>(), std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(duration.usec<int64_t>(), usecs);
+  EXPECT_EQ(duration.usec<uint64_t>(), usecs);
+  EXPECT_EQ(duration.usec<float>(), usecs);
+  EXPECT_EQ(duration.usec<double>(), usecs);
+}
+
+TEST(Duration, ConstructOverflow) {
+  const int64_t secs = 1000000000000000;
+  const int64_t msecs = secs * 1000;
+
+  freeisle::time::Duration duration = freeisle::time::Duration::msec(msecs);
+
+  EXPECT_EQ(duration.sec<int32_t>(), std::numeric_limits<int32_t>::max());
+  EXPECT_EQ(duration.sec<uint32_t>(), std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(duration.sec<int64_t>(), 9223372036855);
+  EXPECT_EQ(duration.sec<uint64_t>(), 9223372036855);
+  EXPECT_EQ(duration.sec<float>(), 9223372036854.776f);
+  EXPECT_EQ(duration.sec<double>(), 9223372036854.776);
+
+  EXPECT_EQ(duration.msec<int32_t>(), std::numeric_limits<int32_t>::max());
+  EXPECT_EQ(duration.msec<uint32_t>(), std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(duration.msec<int64_t>(), 9223372036854776);
+  EXPECT_EQ(duration.msec<uint64_t>(), 9223372036854776);
+  EXPECT_EQ(duration.msec<float>(), 9223372036854776.f);
+  EXPECT_EQ(duration.msec<double>(), 9223372036854776.);
+
+  EXPECT_EQ(duration.usec<int32_t>(), std::numeric_limits<int32_t>::max());
+  EXPECT_EQ(duration.usec<uint32_t>(), std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(duration.usec<int64_t>(), std::numeric_limits<int64_t>::max());
+  EXPECT_EQ(duration.usec<uint64_t>(), std::numeric_limits<int64_t>::max());
+  EXPECT_EQ(duration.usec<float>(), std::numeric_limits<int64_t>::max());
+  EXPECT_EQ(duration.usec<double>(), std::numeric_limits<int64_t>::max());
+}
+
+TEST(Duration, ConstructOverflowFp) {
+  const int64_t secs = 1000000000000000;
+  const int64_t msecs = secs * 1000;
+
+  freeisle::time::Duration duration =
+      freeisle::time::Duration::msec(static_cast<double>(msecs));
+
+  EXPECT_EQ(duration.sec<int32_t>(), std::numeric_limits<int32_t>::max());
+  EXPECT_EQ(duration.sec<uint32_t>(), std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(duration.sec<int64_t>(), 9223372036855);
+  EXPECT_EQ(duration.sec<uint64_t>(), 9223372036855);
+  EXPECT_EQ(duration.sec<float>(), 9223372036854.776f);
+  EXPECT_EQ(duration.sec<double>(), 9223372036854.776);
+
+  EXPECT_EQ(duration.msec<int32_t>(), std::numeric_limits<int32_t>::max());
+  EXPECT_EQ(duration.msec<uint32_t>(), std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(duration.msec<int64_t>(), 9223372036854776);
+  EXPECT_EQ(duration.msec<uint64_t>(), 9223372036854776);
+  EXPECT_EQ(duration.msec<float>(), 9223372036854776.f);
+  EXPECT_EQ(duration.msec<double>(), 9223372036854776.);
+
+  EXPECT_EQ(duration.usec<int32_t>(), std::numeric_limits<int32_t>::max());
+  EXPECT_EQ(duration.usec<uint32_t>(), std::numeric_limits<uint32_t>::max());
+  EXPECT_EQ(duration.usec<int64_t>(), std::numeric_limits<int64_t>::max());
+  EXPECT_EQ(duration.usec<uint64_t>(), std::numeric_limits<int64_t>::max());
+  EXPECT_EQ(duration.usec<float>(), std::numeric_limits<int64_t>::max());
+  EXPECT_EQ(duration.usec<double>(), std::numeric_limits<int64_t>::max());
+}
+
+TEST(Duration, ConstructUnderflow) {
+  const int64_t secs = -1000000000000000;
+  const int64_t msecs = secs * 1000;
+
+  freeisle::time::Duration duration = freeisle::time::Duration::msec(msecs);
+
+  EXPECT_EQ(duration.sec<int32_t>(), -std::numeric_limits<int32_t>::max());
+  EXPECT_EQ(duration.sec<uint32_t>(), 0);
+  EXPECT_EQ(duration.sec<int64_t>(), -9223372036855);
+  EXPECT_EQ(duration.sec<uint64_t>(), 0);
+  EXPECT_EQ(duration.sec<float>(), -9223372036854.776f);
+  EXPECT_EQ(duration.sec<double>(), -9223372036854.776);
+
+  EXPECT_EQ(duration.msec<int32_t>(), -std::numeric_limits<int32_t>::max());
+  EXPECT_EQ(duration.msec<uint32_t>(), 0);
+  EXPECT_EQ(duration.msec<int64_t>(), -9223372036854776);
+  EXPECT_EQ(duration.msec<uint64_t>(), 0);
+  EXPECT_EQ(duration.msec<float>(), -9223372036854776.f);
+  EXPECT_EQ(duration.msec<double>(), -9223372036854776.);
+
+  EXPECT_EQ(duration.usec<int32_t>(), -std::numeric_limits<int32_t>::max());
+  EXPECT_EQ(duration.usec<uint32_t>(), 0);
+  EXPECT_EQ(duration.usec<int64_t>(), -std::numeric_limits<int64_t>::max());
+  EXPECT_EQ(duration.usec<uint64_t>(), 0);
+  EXPECT_EQ(duration.usec<float>(), -std::numeric_limits<int64_t>::max());
+  EXPECT_EQ(duration.usec<double>(), -std::numeric_limits<int64_t>::max());
+}
+
+TEST(Duration, ConstructUnderflowFp) {
+  const int64_t secs = -1000000000000000;
+  const int64_t msecs = secs * 1000;
+
+  freeisle::time::Duration duration =
+      freeisle::time::Duration::msec(static_cast<double>(msecs));
+
+  EXPECT_EQ(duration.sec<int32_t>(), -std::numeric_limits<int32_t>::max());
+  EXPECT_EQ(duration.sec<uint32_t>(), 0);
+  EXPECT_EQ(duration.sec<int64_t>(), -9223372036855);
+  EXPECT_EQ(duration.sec<uint64_t>(), 0);
+  EXPECT_EQ(duration.sec<float>(), -9223372036854.776f);
+  EXPECT_EQ(duration.sec<double>(), -9223372036854.776);
+
+  EXPECT_EQ(duration.msec<int32_t>(), -std::numeric_limits<int32_t>::max());
+  EXPECT_EQ(duration.msec<uint32_t>(), 0);
+  EXPECT_EQ(duration.msec<int64_t>(), -9223372036854776);
+  EXPECT_EQ(duration.msec<uint64_t>(), 0);
+  EXPECT_EQ(duration.msec<float>(), -9223372036854776.f);
+  EXPECT_EQ(duration.msec<double>(), -9223372036854776.);
+
+  EXPECT_EQ(duration.usec<int32_t>(), -std::numeric_limits<int32_t>::max());
+  EXPECT_EQ(duration.usec<uint32_t>(), 0);
+  EXPECT_EQ(duration.usec<int64_t>(), -std::numeric_limits<int64_t>::max());
+  EXPECT_EQ(duration.usec<uint64_t>(), 0);
+  EXPECT_EQ(duration.usec<float>(), -std::numeric_limits<int64_t>::max());
+  EXPECT_EQ(duration.usec<double>(), -std::numeric_limits<int64_t>::max());
+}
+
+TEST(Duration, Add) {
+  freeisle::time::Duration d1 = freeisle::time::Duration::sec(2);
+  freeisle::time::Duration d2 = freeisle::time::Duration::sec(3);
+
+  EXPECT_EQ((d1 + d2).sec<int32_t>(), 5);
+}
+
+TEST(Duration, AddNegative) {
+  freeisle::time::Duration d1 = freeisle::time::Duration::sec(2);
+  freeisle::time::Duration d2 = freeisle::time::Duration::sec(-3);
+
+  EXPECT_EQ((d1 + d2).sec<int32_t>(), -1);
+}
+
+TEST(Duration, AddOverflow) {
+  freeisle::time::Duration d1 =
+      freeisle::time::Duration::usec(std::numeric_limits<int64_t>::max() - 2);
+  freeisle::time::Duration d2 = freeisle::time::Duration::usec(3);
+
+  EXPECT_EQ((d1 + d2).usec<int64_t>(), std::numeric_limits<int64_t>::max());
+}
+
+TEST(Duration, Subtract) {
+  freeisle::time::Duration d1 = freeisle::time::Duration::sec(2);
+  freeisle::time::Duration d2 = freeisle::time::Duration::sec(3);
+
+  EXPECT_EQ((d1 - d2).sec<int32_t>(), -1);
+}
+
+TEST(Duration, SubtractNegative) {
+  freeisle::time::Duration d1 = freeisle::time::Duration::sec(2);
+  freeisle::time::Duration d2 = freeisle::time::Duration::sec(-3);
+
+  EXPECT_EQ((d1 - d2).sec<int32_t>(), 5);
+}
+
+TEST(Duration, SubtractOverflow) {
+  freeisle::time::Duration d1 = freeisle::time::Duration::usec(-10);
+  freeisle::time::Duration d2 =
+      freeisle::time::Duration::usec(std::numeric_limits<int64_t>::max() - 2);
+
+  EXPECT_EQ((d1 - d2).usec<int64_t>(), -std::numeric_limits<int64_t>::max());
+}
+
+TEST(Duration, Multiply) {
+  freeisle::time::Duration d1 = freeisle::time::Duration::sec(6);
+
+  EXPECT_EQ((d1 * 5).sec<int32_t>(), 30);
+  EXPECT_EQ((5 * d1).sec<int32_t>(), 30);
+
+  EXPECT_EQ((d1 * -4).sec<int32_t>(), -24);
+  EXPECT_EQ((-4 * d1).sec<int32_t>(), -24);
+}
+
+TEST(Duration, MultiplyFloat) {
+  freeisle::time::Duration d1 = freeisle::time::Duration::sec(6);
+
+  EXPECT_EQ((d1 * 5.5).sec<int32_t>(), 33);
+  EXPECT_EQ((5.5 * d1).sec<int32_t>(), 33);
+
+  EXPECT_EQ((d1 * 0.5).sec<int32_t>(), 3);
+  EXPECT_EQ((0.5 * d1).sec<int32_t>(), 3);
+
+  EXPECT_EQ((d1 * 0.).sec<int32_t>(), 0);
+  EXPECT_EQ((0. * d1).sec<int32_t>(), 0);
+
+  EXPECT_EQ((d1 * -2.).sec<int32_t>(), -12);
+  EXPECT_EQ((-2. * d1).sec<int32_t>(), -12);
+}
+
+TEST(Duration, MultiplyOverflowPositive) {
+  freeisle::time::Duration d1 =
+      freeisle::time::Duration::sec(std::numeric_limits<int64_t>::max() - 2);
+
+  EXPECT_EQ((d1 * 2).usec<int64_t>(), std::numeric_limits<int64_t>::max());
+  EXPECT_EQ((2 * d1).usec<int64_t>(), std::numeric_limits<int64_t>::max());
+
+  EXPECT_EQ((d1 * -2).usec<int64_t>(), -std::numeric_limits<int64_t>::max());
+  EXPECT_EQ((-2 * d1).usec<int64_t>(), -std::numeric_limits<int64_t>::max());
+}
+
+TEST(Duration, MultiplyOverflowNegative) {
+  freeisle::time::Duration d1 =
+      freeisle::time::Duration::sec(-std::numeric_limits<int64_t>::max() + 2);
+
+  EXPECT_EQ((d1 * 2).usec<int64_t>(), -std::numeric_limits<int64_t>::max());
+  EXPECT_EQ((2 * d1).usec<int64_t>(), -std::numeric_limits<int64_t>::max());
+
+  EXPECT_EQ((d1 * -2).usec<int64_t>(), std::numeric_limits<int64_t>::max());
+  EXPECT_EQ((-2 * d1).usec<int64_t>(), std::numeric_limits<int64_t>::max());
+}
+
+TEST(Duration, Divide) {
+  freeisle::time::Duration d1 = freeisle::time::Duration::sec(6);
+
+  EXPECT_EQ((d1 / 3).sec<int32_t>(), 2);
+}
+
+TEST(Duration, DivideFloat) {
+  freeisle::time::Duration d1 = freeisle::time::Duration::sec(60);
+
+  EXPECT_EQ((d1 / 2.5).sec<int32_t>(), 24);
+  EXPECT_EQ((d1 / 0.5).sec<int32_t>(), 120);
+}
+
+TEST(Duration, DivideOverflow) {
+  freeisle::time::Duration d1 =
+      freeisle::time::Duration::sec(std::numeric_limits<int64_t>::max() - 2);
+
+  EXPECT_EQ((d1 / 0.5).usec<int64_t>(), std::numeric_limits<int64_t>::max());
+  EXPECT_EQ((d1 / -0.5).usec<int64_t>(), -std::numeric_limits<int64_t>::max());
+}

--- a/src/engine/time/test/TestInstant.cc
+++ b/src/engine/time/test/TestInstant.cc
@@ -1,0 +1,150 @@
+#include "time/Instant.hh"
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+TEST(Instant, Default) {
+  freeisle::time::Instant instant;
+  EXPECT_EQ(instant.unixSec(), 0);
+  EXPECT_EQ(instant.unixMsec(), 0);
+  EXPECT_EQ(instant.unixUsec(), 0);
+}
+
+TEST(Instant, ConstructFromSec) {
+  freeisle::time::Instant instant = freeisle::time::Instant::unixSec(3);
+
+  EXPECT_EQ(instant.unixSec(), 3);
+  EXPECT_EQ(instant.unixMsec(), 3000);
+  EXPECT_EQ(instant.unixUsec(), 3000000);
+}
+
+TEST(Instant, ConstructFromMsec) {
+  freeisle::time::Instant instant = freeisle::time::Instant::unixMsec(3000);
+
+  EXPECT_EQ(instant.unixSec(), 3);
+  EXPECT_EQ(instant.unixMsec(), 3000);
+  EXPECT_EQ(instant.unixUsec(), 3000000);
+}
+
+TEST(Instant, ConstructFromUsec) {
+  freeisle::time::Instant instant = freeisle::time::Instant::unixUsec(3000000);
+
+  EXPECT_EQ(instant.unixSec(), 3);
+  EXPECT_EQ(instant.unixMsec(), 3000);
+  EXPECT_EQ(instant.unixUsec(), 3000000);
+}
+
+TEST(Instant, ConstructGregorian) {
+  const freeisle::time::Instant::Gregorian g{
+      .year = 2021,
+      .month = 5,
+      .day = 16,
+      .hour = 16,
+      .minute = 1,
+      .second = 31,
+      .microsecond = 421991,
+  };
+
+  const freeisle::time::Instant instant = freeisle::time::Instant::gregorian(g);
+
+  EXPECT_EQ(instant.unixSec(), 1621180891);
+  EXPECT_EQ(instant.unixMsec(), 1621180891422);
+  EXPECT_EQ(instant.unixUsec(), 1621180891421991);
+}
+
+TEST(Instant, ConstructGregorianRoundUp) {
+  const freeisle::time::Instant::Gregorian g{
+      .year = 2021,
+      .month = 5,
+      .day = 16,
+      .hour = 16,
+      .minute = 1,
+      .second = 31,
+      .microsecond = 521991,
+  };
+
+  const freeisle::time::Instant instant = freeisle::time::Instant::gregorian(g);
+
+  EXPECT_EQ(instant.unixSec(), 1621180892);
+  EXPECT_EQ(instant.unixMsec(), 1621180891522);
+  EXPECT_EQ(instant.unixUsec(), 1621180891521991);
+}
+
+TEST(Instant, ConstructGregorianSeparate) {
+  const freeisle::time::Instant instant =
+      freeisle::time::Instant::gregorian(2021, 5, 16, 16, 1, 31, 421991);
+
+  EXPECT_EQ(instant.unixSec(), 1621180891);
+  EXPECT_EQ(instant.unixMsec(), 1621180891422);
+  EXPECT_EQ(instant.unixUsec(), 1621180891421991);
+}
+
+TEST(Instant, BreakDown) {
+  const freeisle::time::Instant instant =
+      freeisle::time::Instant::unixUsec(1621180891421991);
+
+  const freeisle::time::Instant::Gregorian g = instant.break_down();
+
+  EXPECT_EQ(g.year, 2021);
+  EXPECT_EQ(g.month, 5);
+  EXPECT_EQ(g.day, 16);
+  EXPECT_EQ(g.hour, 16);
+  EXPECT_EQ(g.minute, 1);
+  EXPECT_EQ(g.second, 31);
+  EXPECT_EQ(g.microsecond, 421991);
+}
+
+TEST(Instant, SubtractTwoInstants) {
+  const freeisle::time::Instant instant1 =
+      freeisle::time::Instant::unixUsec(1621180881421991);
+  const freeisle::time::Instant instant2 =
+      freeisle::time::Instant::unixUsec(1621180891421991);
+  const freeisle::time::Duration dur1 = instant2 - instant1;
+  const freeisle::time::Duration dur2 = instant1 - instant2;
+
+  EXPECT_EQ(dur1, -dur2);
+
+  EXPECT_EQ(dur1.sec<int64_t>(), 10);
+  EXPECT_EQ(dur2.sec<int64_t>(), -10);
+}
+
+TEST(Instant, InstantPlusDuration) {
+  const freeisle::time::Instant instant =
+      freeisle::time::Instant::unixUsec(1621180881421991);
+  const freeisle::time::Duration dur = freeisle::time::Duration::sec(10);
+
+  freeisle::time::Instant v1 = instant;
+  const freeisle::time::Instant v2 = instant + dur;
+  v1 += dur;
+
+  EXPECT_EQ(v1.unixUsec(), 1621180891421991);
+  EXPECT_EQ(v2.unixUsec(), 1621180891421991);
+
+  freeisle::time::Instant v3 = instant;
+  const freeisle::time::Instant v4 = instant + (-dur);
+  v3 += (-dur);
+
+  EXPECT_EQ(v3.unixUsec(), 1621180871421991);
+  EXPECT_EQ(v4.unixUsec(), 1621180871421991);
+}
+
+TEST(Instant, InstantMinusDuration) {
+  const freeisle::time::Instant instant =
+      freeisle::time::Instant::unixUsec(1621180881421991);
+  const freeisle::time::Duration dur = freeisle::time::Duration::sec(10);
+
+  freeisle::time::Instant v1 = instant;
+  const freeisle::time::Instant v2 = instant - dur;
+  v1 -= dur;
+
+  EXPECT_EQ(v1.unixUsec(), 1621180871421991);
+  EXPECT_EQ(v2.unixUsec(), 1621180871421991);
+
+  freeisle::time::Instant v3 = instant;
+  const freeisle::time::Instant v4 = instant - (-dur);
+  v3 -= (-dur);
+
+  EXPECT_EQ(v3.unixUsec(), 1621180891421991);
+  EXPECT_EQ(v4.unixUsec(), 1621180891421991);
+}

--- a/src/engine/time/test/meson.build
+++ b/src/engine/time/test/meson.build
@@ -1,0 +1,7 @@
+t = executable(
+  'time_test',
+  ['TestDuration.cc'],
+  dependencies : gtest,
+  include_directories : engine)
+
+test('time', t)

--- a/src/engine/time/test/meson.build
+++ b/src/engine/time/test/meson.build
@@ -1,7 +1,8 @@
 t = executable(
   'time_test',
-  ['TestDuration.cc'],
+  ['TestDuration.cc', 'TestInstant.cc'],
   dependencies : gtest,
+  link_with : time_lib,
   include_directories : engine)
 
 test('time', t)


### PR DESCRIPTION
These allow time representation and arithmetics with some protection from over/underflow. I decided to skip `std::chrono` so that the definition of a time point (Instant) is not tied to a particular clock but simply defined to be relative to the Unix epoch. Also, microsecond precision is good enough for everyone, we don't need the full flexibility that 'std::chrono` provides, and can avoid some of its complexity. This should then also make mocking time in unit tests a bit easier. 