### PR TITLE
Provide include mapping from JSON loader

### DIFF
--- a/src/engine/json/test/data/defg_removal.json
+++ b/src/engine/json/test/data/defg_removal.json
@@ -1,5 +1,5 @@
 {
   "include": "defg_working.json",
-  "f": "overridden",
-  "h": null
+  "h": null,
+  "f": "overridden"
 }


### PR DESCRIPTION
This mapping contains all data needed to save the loaded object back with the
same include references.