### PR TITLE
Small code style fix

### DIFF
--- a/src/engine/log/test/TestSystem.cc
+++ b/src/engine/log/test/TestSystem.cc
@@ -9,7 +9,7 @@ namespace {
 class MockClock : public freeisle::time::Clock {
 public:
   virtual freeisle::time::Instant get_time() override {
-    return freeisle::time::Instant::unixSec(1621371327);
+    return freeisle::time::Instant::unix_sec(1621371327);
   }
 
   virtual freeisle::time::Duration get_monotonic_time() override {
@@ -47,7 +47,7 @@ TEST(System, Simple) {
   logger.log(freeisle::log::Level::Info, "my message");
 
   ASSERT_TRUE(sink.called_);
-  EXPECT_EQ(sink.instant_, freeisle::time::Instant::unixSec(1621371327));
+  EXPECT_EQ(sink.instant_, freeisle::time::Instant::unix_sec(1621371327));
   EXPECT_EQ(sink.level_, freeisle::log::Level::Info);
   EXPECT_EQ(sink.domain_, "spectacle");
   EXPECT_EQ(sink.message_, "my message");
@@ -62,7 +62,7 @@ TEST(System, Format) {
   logger.info("test message with {} goodies", 5);
 
   ASSERT_TRUE(sink.called_);
-  EXPECT_EQ(sink.instant_, freeisle::time::Instant::unixSec(1621371327));
+  EXPECT_EQ(sink.instant_, freeisle::time::Instant::unix_sec(1621371327));
   EXPECT_EQ(sink.level_, freeisle::log::Level::Info);
   EXPECT_EQ(sink.domain_, "spectacle");
   EXPECT_EQ(sink.message_, "test message with 5 goodies");
@@ -78,7 +78,7 @@ TEST(System, ChildLogger) {
   child_logger.info("test message");
 
   ASSERT_TRUE(sink.called_);
-  EXPECT_EQ(sink.instant_, freeisle::time::Instant::unixSec(1621371327));
+  EXPECT_EQ(sink.instant_, freeisle::time::Instant::unix_sec(1621371327));
   EXPECT_EQ(sink.level_, freeisle::log::Level::Info);
   EXPECT_EQ(sink.domain_, "spectacle.rock");
   EXPECT_EQ(sink.message_, "test message");
@@ -106,7 +106,7 @@ TEST(System, ThresholdConfig) {
 
   superbunny_logger.warning("test message");
   ASSERT_TRUE(sink.called_);
-  EXPECT_EQ(sink.instant_, freeisle::time::Instant::unixSec(1621371327));
+  EXPECT_EQ(sink.instant_, freeisle::time::Instant::unix_sec(1621371327));
   EXPECT_EQ(sink.level_, freeisle::log::Level::Warning);
   EXPECT_EQ(sink.domain_, "superbunny");
   EXPECT_EQ(sink.message_, "test message");
@@ -118,7 +118,7 @@ TEST(System, ThresholdConfig) {
 
   spectacle_logger.warning("test message");
   ASSERT_TRUE(sink.called_);
-  EXPECT_EQ(sink.instant_, freeisle::time::Instant::unixSec(1621371327));
+  EXPECT_EQ(sink.instant_, freeisle::time::Instant::unix_sec(1621371327));
   EXPECT_EQ(sink.level_, freeisle::log::Level::Warning);
   EXPECT_EQ(sink.domain_, "spectacle");
   EXPECT_EQ(sink.message_, "test message");
@@ -126,7 +126,7 @@ TEST(System, ThresholdConfig) {
 
   spectacle_logger.info("test message");
   ASSERT_TRUE(sink.called_);
-  EXPECT_EQ(sink.instant_, freeisle::time::Instant::unixSec(1621371327));
+  EXPECT_EQ(sink.instant_, freeisle::time::Instant::unix_sec(1621371327));
   EXPECT_EQ(sink.level_, freeisle::log::Level::Info);
   EXPECT_EQ(sink.domain_, "spectacle");
   EXPECT_EQ(sink.message_, "test message");
@@ -138,7 +138,7 @@ TEST(System, ThresholdConfig) {
 
   spectacle_mountain_logger.info("test message");
   ASSERT_TRUE(sink.called_);
-  EXPECT_EQ(sink.instant_, freeisle::time::Instant::unixSec(1621371327));
+  EXPECT_EQ(sink.instant_, freeisle::time::Instant::unix_sec(1621371327));
   EXPECT_EQ(sink.level_, freeisle::log::Level::Info);
   EXPECT_EQ(sink.domain_, "spectacle.mountain");
   EXPECT_EQ(sink.message_, "test message");
@@ -146,7 +146,7 @@ TEST(System, ThresholdConfig) {
 
   spectacle_mountain_logger.debug("test message");
   ASSERT_TRUE(sink.called_);
-  EXPECT_EQ(sink.instant_, freeisle::time::Instant::unixSec(1621371327));
+  EXPECT_EQ(sink.instant_, freeisle::time::Instant::unix_sec(1621371327));
   EXPECT_EQ(sink.level_, freeisle::log::Level::Debug);
   EXPECT_EQ(sink.domain_, "spectacle.mountain");
   EXPECT_EQ(sink.message_, "test message");
@@ -154,7 +154,7 @@ TEST(System, ThresholdConfig) {
 
   spectacle_rock_logger.fatal("test message");
   ASSERT_TRUE(sink.called_);
-  EXPECT_EQ(sink.instant_, freeisle::time::Instant::unixSec(1621371327));
+  EXPECT_EQ(sink.instant_, freeisle::time::Instant::unix_sec(1621371327));
   EXPECT_EQ(sink.level_, freeisle::log::Level::Fatal);
   EXPECT_EQ(sink.domain_, "spectacle.rock");
   EXPECT_EQ(sink.message_, "test message");
@@ -162,7 +162,7 @@ TEST(System, ThresholdConfig) {
 
   spectacle_rock_logger.error("test message");
   ASSERT_TRUE(sink.called_);
-  EXPECT_EQ(sink.instant_, freeisle::time::Instant::unixSec(1621371327));
+  EXPECT_EQ(sink.instant_, freeisle::time::Instant::unix_sec(1621371327));
   EXPECT_EQ(sink.level_, freeisle::log::Level::Error);
   EXPECT_EQ(sink.domain_, "spectacle.rock");
   EXPECT_EQ(sink.message_, "test message");

--- a/src/engine/png/test/TestPng.cc
+++ b/src/engine/png/test/TestPng.cc
@@ -21,7 +21,7 @@ namespace {
 class MockClock : public freeisle::time::Clock {
 public:
   virtual freeisle::time::Instant get_time() override {
-    return freeisle::time::Instant::unixSec(1621371327);
+    return freeisle::time::Instant::unix_sec(1621371327);
   }
 
   virtual freeisle::time::Duration get_monotonic_time() override {
@@ -141,7 +141,7 @@ TEST_F(PngTest, DecodeCorrupt) {
       std::runtime_error);
 
   EXPECT_TRUE(sink.called_);
-  EXPECT_EQ(sink.instant_.unixSec(), 1621371327);
+  EXPECT_EQ(sink.instant_.unix_sec(), 1621371327);
   EXPECT_EQ(sink.level_, freeisle::log::Level::Error);
   EXPECT_EQ(sink.domain_, "test");
 }
@@ -180,7 +180,7 @@ TEST_F(PngTest, DecodeInfoStructWarn) {
       freeisle::png::decode_rgb8(data.data(), data.size(), std::move(logger));
 
   EXPECT_TRUE(sink.called_);
-  EXPECT_EQ(sink.instant_.unixSec(), 1621371327);
+  EXPECT_EQ(sink.instant_.unix_sec(), 1621371327);
   EXPECT_EQ(sink.level_, freeisle::log::Level::Warning);
   EXPECT_EQ(sink.domain_, "test");
   EXPECT_EQ(sink.message_, "Mock warning");
@@ -286,7 +286,7 @@ TEST_F(PngTest, EncodeWriteFailure) {
       std::runtime_error);
 
   EXPECT_TRUE(sink.called_);
-  EXPECT_EQ(sink.instant_.unixSec(), 1621371327);
+  EXPECT_EQ(sink.instant_.unix_sec(), 1621371327);
   EXPECT_EQ(sink.level_, freeisle::log::Level::Error);
   EXPECT_EQ(sink.domain_, "test.encode");
   EXPECT_EQ(sink.message_, "Mock error");

--- a/src/engine/time/Instant.cc
+++ b/src/engine/time/Instant.cc
@@ -4,15 +4,15 @@
 
 namespace freeisle::time {
 
-Instant Instant::unixSec(int64_t timestamp) {
+Instant Instant::unix_sec(int64_t timestamp) {
   return Instant(Duration::sec(timestamp));
 }
 
-Instant Instant::unixMsec(int64_t timestamp_ms) {
+Instant Instant::unix_msec(int64_t timestamp_ms) {
   return Instant(Duration::msec(timestamp_ms));
 }
 
-Instant Instant::unixUsec(int64_t timestamp_us) {
+Instant Instant::unix_usec(int64_t timestamp_us) {
   return Instant(Duration::usec(timestamp_us));
 }
 
@@ -63,11 +63,11 @@ Instant Instant::gregorian(int32_t year, uint32_t month, uint32_t day,
   });
 }
 
-int64_t Instant::unixSec() const { return val.sec<int64_t>(); }
+int64_t Instant::unix_sec() const { return val.sec<int64_t>(); }
 
-int64_t Instant::unixMsec() const { return val.msec<int64_t>(); }
+int64_t Instant::unix_msec() const { return val.msec<int64_t>(); }
 
-int64_t Instant::unixUsec() const { return val.usec<int64_t>(); }
+int64_t Instant::unix_usec() const { return val.usec<int64_t>(); }
 
 Instant::Gregorian Instant::break_down() const {
   struct tm tm;

--- a/src/engine/time/Instant.hh
+++ b/src/engine/time/Instant.hh
@@ -63,17 +63,17 @@ public:
   /**
    * Create an instant from a unix timestamp in seconds.
    */
-  static Instant unixSec(int64_t timestamp);
+  static Instant unix_sec(int64_t timestamp);
 
   /**
    * Create an instant from a unix timestamp in milliseconds.
    */
-  static Instant unixMsec(int64_t timestamp_ms);
+  static Instant unix_msec(int64_t timestamp_ms);
 
   /**
    * Create an instant from a unix timestamp in microseconds.
    */
-  static Instant unixUsec(int64_t timestamp_us);
+  static Instant unix_usec(int64_t timestamp_us);
 
   /**
    * Construct an instant from a Gregorian representation.
@@ -94,18 +94,18 @@ public:
    * Returns the UNIX timestamp represented by this instant, in seconds.
    * Fractional seconds are rounded toward the nearest second.
    */
-  int64_t unixSec() const;
+  int64_t unix_sec() const;
 
   /**
    * Returns the UNIX timestamp represented by this instant, in milliseconds.
    * Fractional milliseconds are rounded toward the nearest millisecond.
    */
-  int64_t unixMsec() const;
+  int64_t unix_msec() const;
 
   /**
    * Returns the UNIX timestamp represented by this instant, in microseconds.
    */
-  int64_t unixUsec() const;
+  int64_t unix_usec() const;
 
   /**
    * Break down the instant into the components of the

--- a/src/engine/time/SystemClock.cc
+++ b/src/engine/time/SystemClock.cc
@@ -32,7 +32,7 @@ SystemClock::SystemClock()
 
 Instant SystemClock::get_time() {
   const int64_t clockval = query_clock(CLOCK_REALTIME);
-  return Instant::unixUsec(clockval);
+  return Instant::unix_usec(clockval);
 }
 
 Duration SystemClock::get_monotonic_time() {

--- a/src/engine/time/test/TestInstant.cc
+++ b/src/engine/time/test/TestInstant.cc
@@ -6,33 +6,33 @@
 
 TEST(Instant, Default) {
   freeisle::time::Instant instant;
-  EXPECT_EQ(instant.unixSec(), 0);
-  EXPECT_EQ(instant.unixMsec(), 0);
-  EXPECT_EQ(instant.unixUsec(), 0);
+  EXPECT_EQ(instant.unix_sec(), 0);
+  EXPECT_EQ(instant.unix_msec(), 0);
+  EXPECT_EQ(instant.unix_usec(), 0);
 }
 
 TEST(Instant, ConstructFromSec) {
-  freeisle::time::Instant instant = freeisle::time::Instant::unixSec(3);
+  freeisle::time::Instant instant = freeisle::time::Instant::unix_sec(3);
 
-  EXPECT_EQ(instant.unixSec(), 3);
-  EXPECT_EQ(instant.unixMsec(), 3000);
-  EXPECT_EQ(instant.unixUsec(), 3000000);
+  EXPECT_EQ(instant.unix_sec(), 3);
+  EXPECT_EQ(instant.unix_msec(), 3000);
+  EXPECT_EQ(instant.unix_usec(), 3000000);
 }
 
 TEST(Instant, ConstructFromMsec) {
-  freeisle::time::Instant instant = freeisle::time::Instant::unixMsec(3000);
+  freeisle::time::Instant instant = freeisle::time::Instant::unix_msec(3000);
 
-  EXPECT_EQ(instant.unixSec(), 3);
-  EXPECT_EQ(instant.unixMsec(), 3000);
-  EXPECT_EQ(instant.unixUsec(), 3000000);
+  EXPECT_EQ(instant.unix_sec(), 3);
+  EXPECT_EQ(instant.unix_msec(), 3000);
+  EXPECT_EQ(instant.unix_usec(), 3000000);
 }
 
 TEST(Instant, ConstructFromUsec) {
-  freeisle::time::Instant instant = freeisle::time::Instant::unixUsec(3000000);
+  freeisle::time::Instant instant = freeisle::time::Instant::unix_usec(3000000);
 
-  EXPECT_EQ(instant.unixSec(), 3);
-  EXPECT_EQ(instant.unixMsec(), 3000);
-  EXPECT_EQ(instant.unixUsec(), 3000000);
+  EXPECT_EQ(instant.unix_sec(), 3);
+  EXPECT_EQ(instant.unix_msec(), 3000);
+  EXPECT_EQ(instant.unix_usec(), 3000000);
 }
 
 TEST(Instant, ConstructGregorian) {
@@ -48,9 +48,9 @@ TEST(Instant, ConstructGregorian) {
 
   const freeisle::time::Instant instant = freeisle::time::Instant::gregorian(g);
 
-  EXPECT_EQ(instant.unixSec(), 1621180891);
-  EXPECT_EQ(instant.unixMsec(), 1621180891422);
-  EXPECT_EQ(instant.unixUsec(), 1621180891421991);
+  EXPECT_EQ(instant.unix_sec(), 1621180891);
+  EXPECT_EQ(instant.unix_msec(), 1621180891422);
+  EXPECT_EQ(instant.unix_usec(), 1621180891421991);
 }
 
 TEST(Instant, ConstructGregorianRoundUp) {
@@ -66,23 +66,23 @@ TEST(Instant, ConstructGregorianRoundUp) {
 
   const freeisle::time::Instant instant = freeisle::time::Instant::gregorian(g);
 
-  EXPECT_EQ(instant.unixSec(), 1621180892);
-  EXPECT_EQ(instant.unixMsec(), 1621180891522);
-  EXPECT_EQ(instant.unixUsec(), 1621180891521991);
+  EXPECT_EQ(instant.unix_sec(), 1621180892);
+  EXPECT_EQ(instant.unix_msec(), 1621180891522);
+  EXPECT_EQ(instant.unix_usec(), 1621180891521991);
 }
 
 TEST(Instant, ConstructGregorianSeparate) {
   const freeisle::time::Instant instant =
       freeisle::time::Instant::gregorian(2021, 5, 16, 16, 1, 31, 421991);
 
-  EXPECT_EQ(instant.unixSec(), 1621180891);
-  EXPECT_EQ(instant.unixMsec(), 1621180891422);
-  EXPECT_EQ(instant.unixUsec(), 1621180891421991);
+  EXPECT_EQ(instant.unix_sec(), 1621180891);
+  EXPECT_EQ(instant.unix_msec(), 1621180891422);
+  EXPECT_EQ(instant.unix_usec(), 1621180891421991);
 }
 
 TEST(Instant, BreakDown) {
   const freeisle::time::Instant instant =
-      freeisle::time::Instant::unixUsec(1621180891421991);
+      freeisle::time::Instant::unix_usec(1621180891421991);
 
   const freeisle::time::Instant::Gregorian g = instant.break_down();
 
@@ -97,9 +97,9 @@ TEST(Instant, BreakDown) {
 
 TEST(Instant, SubtractTwoInstants) {
   const freeisle::time::Instant instant1 =
-      freeisle::time::Instant::unixUsec(1621180881421991);
+      freeisle::time::Instant::unix_usec(1621180881421991);
   const freeisle::time::Instant instant2 =
-      freeisle::time::Instant::unixUsec(1621180891421991);
+      freeisle::time::Instant::unix_usec(1621180891421991);
   const freeisle::time::Duration dur1 = instant2 - instant1;
   const freeisle::time::Duration dur2 = instant1 - instant2;
 
@@ -111,40 +111,40 @@ TEST(Instant, SubtractTwoInstants) {
 
 TEST(Instant, InstantPlusDuration) {
   const freeisle::time::Instant instant =
-      freeisle::time::Instant::unixUsec(1621180881421991);
+      freeisle::time::Instant::unix_usec(1621180881421991);
   const freeisle::time::Duration dur = freeisle::time::Duration::sec(10);
 
   freeisle::time::Instant v1 = instant;
   const freeisle::time::Instant v2 = instant + dur;
   v1 += dur;
 
-  EXPECT_EQ(v1.unixUsec(), 1621180891421991);
-  EXPECT_EQ(v2.unixUsec(), 1621180891421991);
+  EXPECT_EQ(v1.unix_usec(), 1621180891421991);
+  EXPECT_EQ(v2.unix_usec(), 1621180891421991);
 
   freeisle::time::Instant v3 = instant;
   const freeisle::time::Instant v4 = instant + (-dur);
   v3 += (-dur);
 
-  EXPECT_EQ(v3.unixUsec(), 1621180871421991);
-  EXPECT_EQ(v4.unixUsec(), 1621180871421991);
+  EXPECT_EQ(v3.unix_usec(), 1621180871421991);
+  EXPECT_EQ(v4.unix_usec(), 1621180871421991);
 }
 
 TEST(Instant, InstantMinusDuration) {
   const freeisle::time::Instant instant =
-      freeisle::time::Instant::unixUsec(1621180881421991);
+      freeisle::time::Instant::unix_usec(1621180881421991);
   const freeisle::time::Duration dur = freeisle::time::Duration::sec(10);
 
   freeisle::time::Instant v1 = instant;
   const freeisle::time::Instant v2 = instant - dur;
   v1 -= dur;
 
-  EXPECT_EQ(v1.unixUsec(), 1621180871421991);
-  EXPECT_EQ(v2.unixUsec(), 1621180871421991);
+  EXPECT_EQ(v1.unix_usec(), 1621180871421991);
+  EXPECT_EQ(v2.unix_usec(), 1621180871421991);
 
   freeisle::time::Instant v3 = instant;
   const freeisle::time::Instant v4 = instant - (-dur);
   v3 -= (-dur);
 
-  EXPECT_EQ(v3.unixUsec(), 1621180891421991);
-  EXPECT_EQ(v4.unixUsec(), 1621180891421991);
+  EXPECT_EQ(v3.unix_usec(), 1621180891421991);
+  EXPECT_EQ(v4.unix_usec(), 1621180891421991);
 }

--- a/src/engine/time/test/TestStopWatch.cc
+++ b/src/engine/time/test/TestStopWatch.cc
@@ -7,7 +7,7 @@ namespace {
 class MockClock : public freeisle::time::Clock {
 public:
   virtual freeisle::time::Instant get_time() override {
-    return freeisle::time::Instant::unixSec(0) + d;
+    return freeisle::time::Instant::unix_sec(0) + d;
   }
 
   virtual freeisle::time::Duration get_monotonic_time() override { return d; }

--- a/src/engine/time/test/TestSystemClock.cc
+++ b/src/engine/time/test/TestSystemClock.cc
@@ -17,7 +17,7 @@ TEST(SystemClock, Default) {
 
   freeisle::time::SystemClock clock;
   const freeisle::time::Instant inst = clock.get_time();
-  EXPECT_EQ(inst, freeisle::time::Instant::unixSec(1621283246));
+  EXPECT_EQ(inst, freeisle::time::Instant::unix_sec(1621283246));
 
   const freeisle::time::Duration monotonic1 = clock.get_monotonic_time();
   const freeisle::time::Duration monotonic2 = clock.get_monotonic_time();


### PR DESCRIPTION
Rename Instant::unixSec to Instant::unix_sec, and same for companion functions unix_msec and unix_usec.