### PR TITLE
Add base-64 encoding and decoding

### DIFF
--- a/src/engine/base64/Base64.cc
+++ b/src/engine/base64/Base64.cc
@@ -1,0 +1,139 @@
+#include "base64/Base64.hh"
+
+#include <stdexcept>
+
+#include <cassert>
+
+namespace {
+
+const uint8_t alphabet[] = {
+    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+    'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+    'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/',
+};
+
+const uint8_t inv_alphabet[] = {
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 62,   0xff, 0xff, 0xff, 63,
+    52,   53,   54,   55,   56,   57,   58,   59,   60,   61,   0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0,    1,    2,    3,    4,    5,    6,
+    7,    8,    9,    10,   11,   12,   13,   14,   15,   16,   17,   18,
+    19,   20,   21,   22,   23,   24,   25,   0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 26,   27,   28,   29,   30,   31,   32,   33,   34,   35,   36,
+    37,   38,   39,   40,   41,   42,   43,   44,   45,   46,   47,   48,
+    49,   50,   51,   0xff, 0xff, 0xff, 0xff, 0xff,
+};
+
+static_assert(sizeof(alphabet) == 64, "Base-64 alphabet has incorrect size");
+static_assert(sizeof(inv_alphabet) == 128,
+              "Base-64 inverse alphabet has incorrect size");
+
+uint8_t inv(uint8_t v) {
+  if (v >= 0x80) {
+    throw std::invalid_argument("Non-ASCII input");
+  }
+
+  if (inv_alphabet[v] == 0xff) {
+    throw std::invalid_argument("Illegal character: " +
+                                std::string(&v, &v + 1));
+  }
+
+  return inv_alphabet[v];
+}
+
+} // namespace
+
+namespace freeisle::base64 {
+
+uint64_t encode(const uint8_t *data, uint64_t len, uint8_t *result) {
+  uint8_t *res = result;
+  while (len >= 3) {
+    const uint8_t b1 = (data[0] & 0b1111100) >> 2;
+    const uint8_t b2 =
+        ((data[0] & 0b00000011) << 4) | ((data[1] & 0b11110000) >> 4);
+    const uint8_t b3 =
+        ((data[1] & 0b00001111) << 2) | ((data[2] & 0b11000000) >> 6);
+    const uint8_t b4 = (data[2] & 0b00111111);
+
+    data += 3;
+    len -= 3;
+
+    res[0] = alphabet[b1];
+    res[1] = alphabet[b2];
+    res[2] = alphabet[b3];
+    res[3] = alphabet[b4];
+
+    res += 4;
+  }
+
+  assert(len < 3);
+  switch (len) {
+  case 0:
+    break;
+  case 1:
+    res[0] = alphabet[(data[0] & 0b11111100) >> 2];
+    res[1] = alphabet[(data[0] & 0b00000011) << 4];
+    res[2] = '=';
+    res[3] = '=';
+    res += 4;
+    break;
+  case 2:
+    res[0] = alphabet[(data[0] & 0b1111100) >> 2];
+    res[1] =
+        alphabet[((data[0] & 0b00000011) << 4) | ((data[1] & 0b11110000) >> 4)];
+    res[2] = alphabet[((data[1] & 0b00001111) << 2)];
+    res[3] = '=';
+    res += 4;
+    break;
+  }
+
+  return res - result;
+}
+
+uint64_t decode(const uint8_t *data, uint64_t len, uint8_t *result) {
+  // TODO(armin): skip whitespace
+  while (len > 0 && data[len - 1] == '=') {
+    --len;
+  }
+
+  uint8_t *res = result;
+  while (len >= 4) {
+    const uint8_t b1 = inv(data[0]);
+    const uint8_t b2 = inv(data[1]);
+    const uint8_t b3 = inv(data[2]);
+    const uint8_t b4 = inv(data[3]);
+
+    data += 4;
+    len -= 4;
+
+    res[0] = (b1 << 2) | (b2 >> 4);
+    res[1] = (b2 << 4) | (b3 >> 2);
+    res[2] = (b3 << 6) | b4;
+    res += 3;
+  }
+
+  assert(len < 4);
+  switch (len) {
+  case 0:
+    break;
+  case 1:
+    throw std::invalid_argument("Preliminary end of input");
+  case 2:
+    res[0] = (inv(data[0]) << 2) | (inv(data[1]) >> 4);
+    res += 1;
+    break;
+  case 3:
+    res[0] = (inv(data[0]) << 2) | (inv(data[1]) >> 4);
+    res[1] = (inv(data[1]) << 4) | (inv(data[2]) >> 2);
+    res += 2;
+    break;
+  }
+
+  return res - result;
+}
+
+} // namespace freeisle::base64

--- a/src/engine/base64/Base64.hh
+++ b/src/engine/base64/Base64.hh
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cstdint>
+
+namespace freeisle::base64 {
+
+template <uint64_t X> constexpr uint64_t round_to_next_multiple_of(uint64_t v) {
+  static_assert((X & (X - 1)) == 0, "X must be a power of 2");
+  return (v + (X - 1)) & ~(X - 1);
+}
+
+/**
+ * Encodes a given byte sequence in base-64.
+ * Result must be a at least `round_to_next_multiple_of<4>(len * 4 / 3)` bytes
+ * long.
+ */
+uint64_t encode(const uint8_t *data, uint64_t len, uint8_t *result);
+
+/**
+ * Decodes a byte sequence from base64-encoded data.
+ * Result must be at least `(len * 3 + 3) / 4` bytes long.
+ *
+ * Throws std::invalid_argument if the input is incorrecetly formatted.
+ */
+uint64_t decode(const uint8_t *data, uint64_t len, uint8_t *result);
+
+} // namespace freeisle::base64

--- a/src/engine/base64/meson.build
+++ b/src/engine/base64/meson.build
@@ -1,0 +1,7 @@
+base64_lib = static_library(
+  'base64', [
+    'Base64.cc',
+  ],
+  include_directories : engine)
+
+subdir('test')

--- a/src/engine/base64/test/TestBase64.cc
+++ b/src/engine/base64/test/TestBase64.cc
@@ -1,0 +1,187 @@
+#include "base64/Base64.hh"
+
+#include <gtest/gtest.h>
+
+TEST(Base64, RoundToNextMultiple) {
+  EXPECT_EQ(freeisle::base64::round_to_next_multiple_of<4>(0), 0);
+  EXPECT_EQ(freeisle::base64::round_to_next_multiple_of<4>(1), 4);
+  EXPECT_EQ(freeisle::base64::round_to_next_multiple_of<4>(2), 4);
+  EXPECT_EQ(freeisle::base64::round_to_next_multiple_of<4>(3), 4);
+  EXPECT_EQ(freeisle::base64::round_to_next_multiple_of<4>(4), 4);
+  EXPECT_EQ(freeisle::base64::round_to_next_multiple_of<4>(5), 8);
+  EXPECT_EQ(freeisle::base64::round_to_next_multiple_of<4>(6), 8);
+  EXPECT_EQ(freeisle::base64::round_to_next_multiple_of<4>(7), 8);
+  EXPECT_EQ(freeisle::base64::round_to_next_multiple_of<4>(8), 8);
+  EXPECT_EQ(freeisle::base64::round_to_next_multiple_of<4>(9), 12);
+
+  EXPECT_EQ(freeisle::base64::round_to_next_multiple_of<16>(9), 16);
+  EXPECT_EQ(freeisle::base64::round_to_next_multiple_of<16>(22), 32);
+  EXPECT_EQ(freeisle::base64::round_to_next_multiple_of<16>(96), 96);
+  EXPECT_EQ(freeisle::base64::round_to_next_multiple_of<16>(97), 112);
+}
+
+TEST(Base64, EncodeEmpty) {
+  uint8_t out[8];
+  EXPECT_EQ(
+      freeisle::base64::encode(reinterpret_cast<const uint8_t *>(""), 0, out),
+      0);
+}
+
+TEST(Base64, Encode_f) {
+  uint8_t out[8];
+  EXPECT_EQ(
+      freeisle::base64::encode(reinterpret_cast<const uint8_t *>("f"), 1, out),
+      4);
+  EXPECT_EQ(std::string(out, out + 4), "Zg==");
+}
+
+TEST(Base64, Encode_fo) {
+  uint8_t out[8];
+  EXPECT_EQ(
+      freeisle::base64::encode(reinterpret_cast<const uint8_t *>("fo"), 2, out),
+      4);
+  EXPECT_EQ(std::string(out, out + 4), "Zm8=");
+}
+
+TEST(Base64, Encode_foo) {
+  uint8_t out[8];
+  EXPECT_EQ(freeisle::base64::encode(reinterpret_cast<const uint8_t *>("foo"),
+                                     3, out),
+            4);
+  EXPECT_EQ(std::string(out, out + 4), "Zm9v");
+}
+
+TEST(Base64, Encode_foob) {
+  uint8_t out[8];
+  EXPECT_EQ(freeisle::base64::encode(reinterpret_cast<const uint8_t *>("foob"),
+                                     4, out),
+            8);
+  EXPECT_EQ(std::string(out, out + 8), "Zm9vYg==");
+}
+
+TEST(Base64, Encode_fooba) {
+  uint8_t out[8];
+  EXPECT_EQ(freeisle::base64::encode(reinterpret_cast<const uint8_t *>("fooba"),
+                                     5, out),
+            8);
+  EXPECT_EQ(std::string(out, out + 8), "Zm9vYmE=");
+}
+
+TEST(Base64, Encode_foobar) {
+  uint8_t out[8];
+  EXPECT_EQ(freeisle::base64::encode(
+                reinterpret_cast<const uint8_t *>("foobar"), 6, out),
+            8);
+  EXPECT_EQ(std::string(out, out + 8), "Zm9vYmFy");
+}
+
+TEST(Base64, DecodeEmpty) {
+  uint8_t out[8];
+  EXPECT_EQ(
+      freeisle::base64::decode(reinterpret_cast<const uint8_t *>(""), 0, out),
+      0);
+}
+
+TEST(Base64, DecodePadded_f) {
+  uint8_t out[8];
+  EXPECT_EQ(freeisle::base64::decode(reinterpret_cast<const uint8_t *>("Zg=="),
+                                     4, out),
+            1);
+  EXPECT_EQ(std::string(out, out + 1), "f");
+}
+
+TEST(Base64, DecodeUnpadded_f) {
+  uint8_t out[8];
+  EXPECT_EQ(
+      freeisle::base64::decode(reinterpret_cast<const uint8_t *>("Zg"), 2, out),
+      1);
+  EXPECT_EQ(std::string(out, out + 1), "f");
+}
+
+TEST(Base64, DecodePadded_fo) {
+  uint8_t out[8];
+  EXPECT_EQ(freeisle::base64::decode(reinterpret_cast<const uint8_t *>("Zm8="),
+                                     4, out),
+            2);
+  EXPECT_EQ(std::string(out, out + 2), "fo");
+}
+
+TEST(Base64, DecodeUnpadded_fo) {
+  uint8_t out[8];
+  EXPECT_EQ(freeisle::base64::decode(reinterpret_cast<const uint8_t *>("Zm8"),
+                                     3, out),
+            2);
+  EXPECT_EQ(std::string(out, out + 2), "fo");
+}
+
+TEST(Base64, Decode_foo) {
+  uint8_t out[8];
+  EXPECT_EQ(freeisle::base64::decode(reinterpret_cast<const uint8_t *>("Zm9v"),
+                                     4, out),
+            3);
+  EXPECT_EQ(std::string(out, out + 3), "foo");
+}
+
+TEST(Base64, DecodePadded_foob) {
+  uint8_t out[8];
+  EXPECT_EQ(freeisle::base64::decode(
+                reinterpret_cast<const uint8_t *>("Zm9vYg=="), 8, out),
+            4);
+  EXPECT_EQ(std::string(out, out + 4), "foob");
+}
+
+TEST(Base64, DecodeUnpadded_foob) {
+  uint8_t out[8];
+  EXPECT_EQ(freeisle::base64::decode(
+                reinterpret_cast<const uint8_t *>("Zm9vYg"), 6, out),
+            4);
+  EXPECT_EQ(std::string(out, out + 4), "foob");
+}
+
+TEST(Base64, DecodePadded_fooba) {
+  uint8_t out[8];
+  EXPECT_EQ(freeisle::base64::decode(
+                reinterpret_cast<const uint8_t *>("Zm9vYmE="), 8, out),
+            5);
+  EXPECT_EQ(std::string(out, out + 5), "fooba");
+}
+
+TEST(Base64, DecodeUnpadded_fooba) {
+  uint8_t out[8];
+  EXPECT_EQ(freeisle::base64::decode(
+                reinterpret_cast<const uint8_t *>("Zm9vYmE"), 7, out),
+            5);
+  EXPECT_EQ(std::string(out, out + 5), "fooba");
+}
+
+TEST(Base64, Decode_foobar) {
+  uint8_t out[8];
+  EXPECT_EQ(freeisle::base64::decode(
+                reinterpret_cast<const uint8_t *>("Zm9vYmFy"), 8, out),
+            6);
+  EXPECT_EQ(std::string(out, out + 6), "foobar");
+}
+
+TEST(Base64, DecodeNonAscii) {
+  uint8_t out[8];
+  const uint8_t in[8] = {'Z', '9', 'm', 0xa3, 'Y', 'm', 'F', 'y'};
+  EXPECT_THROW(freeisle::base64::decode(in, 8, out), std::invalid_argument);
+}
+
+TEST(Base64, DecodeIllegalCharacter) {
+  uint8_t out[8];
+  const uint8_t in[8] = {'Z', '9', 'm', ')', 'Y', 'm', 'F', 'y'};
+  EXPECT_THROW(freeisle::base64::decode(in, 8, out), std::invalid_argument);
+}
+
+TEST(Base64, DecodeShortPadded) {
+  uint8_t out[8];
+  const uint8_t in[8] = {'Z', '9', 'm', 'v', 'Y', '=', '=', '='};
+  EXPECT_THROW(freeisle::base64::decode(in, 8, out), std::invalid_argument);
+}
+
+TEST(Base64, DecodeShortUnpadded) {
+  uint8_t out[8];
+  const uint8_t in[5] = {'Z', '9', 'm', 'v', 'Y'};
+  EXPECT_THROW(freeisle::base64::decode(in, 5, out), std::invalid_argument);
+}

--- a/src/engine/base64/test/meson.build
+++ b/src/engine/base64/test/meson.build
@@ -1,0 +1,8 @@
+t = executable(
+  'base64_test',
+  ['TestBase64.cc'],
+  dependencies : gtest,
+  link_with : base64_lib,
+  include_directories : engine)
+
+test('base64', t)

--- a/src/engine/meson.build
+++ b/src/engine/meson.build
@@ -2,6 +2,7 @@ engine = include_directories('.')
 
 # generic stuff
 subdir('core')
+subdir('base64')
 
 # system stuff
 subdir('time')


### PR DESCRIPTION
Used for compact representation of scenarios and saved states where the
image-based parts such as the map are stored inside the main JSON file.