### PR TITLE
Make NullableRef less cumbersome to use

### DIFF
--- a/src/engine/def/Collection.hh
+++ b/src/engine/def/Collection.hh
@@ -83,7 +83,49 @@ private:
  * A reference to an object in a collection which is allowed to not point to
  * any object.
  */
-template <typename T> using NullableRef = std::optional<Ref<T>>;
+template <typename T> class NullableRef {
+public:
+  NullableRef() = default;
+  NullableRef(typename Collection<T>::iterator iter) : ref_(iter) {}
+  NullableRef(Ref<T> ref) : ref_(ref) {}
+
+  /**
+   * Returns whether the NullableRef points to a valid object or not.
+   */
+  explicit operator bool() const { return ref_.has_value(); }
+
+  /**
+   * Returns whether the NullableRef is invalid or not.
+   */
+  bool operator!() const { return !ref_.has_value(); }
+
+  /**
+   * Return the object ID of the referred object.
+   */
+  const std::string &id() const {
+    assert(ref_);
+    return ref_->id();
+  }
+
+  const T &operator*() const {
+    assert(ref_);
+    return **ref_;
+  }
+  const T *operator->() const {
+    assert(ref_);
+    return &**ref_;
+  }
+
+  /**
+   * Return a non-const reference to the referenced object. This is only
+   * safe if the caller can provide a reference to the (non-const) collection
+   * containing the referenced object.
+   */
+  T &get(Collection<T> &collection) { return ref_->get(collection); }
+
+private:
+  std::optional<Ref<T>> ref_;
+};
 
 /**
  * A RefMap is a mapping of object references to some type T. This is used

--- a/src/engine/def/serialize/CollectionSavers.hh
+++ b/src/engine/def/serialize/CollectionSavers.hh
@@ -52,7 +52,7 @@ void save_ref(json::saver::Context &ctx, Json::Value &value, const char *key,
               const def::NullableRef<T> &ref,
               const def::Collection<T> &collection) {
   if (ref) {
-    json::saver::save(ctx, value, key, ref->id());
+    json::saver::save(ctx, value, key, ref.id());
   }
 }
 

--- a/src/engine/def/serialize/test/TestCollectionLoaders.cc
+++ b/src/engine/def/serialize/test/TestCollectionLoaders.cc
@@ -132,7 +132,7 @@ TEST(CollectionLoader, OneObject) {
   EXPECT_EQ(iter->first, "mine");
   EXPECT_EQ(iter->second.name, "my object");
 
-  EXPECT_EQ(&**objects.some_object, &iter->second);
+  EXPECT_EQ(&*objects.some_object, &iter->second);
 
   EXPECT_EQ(objects.object_numbers.size(), 1);
   const freeisle::def::RefMap<Object, uint32_t>::iterator iter2 =
@@ -169,7 +169,7 @@ TEST(CollectionLoader, TwoObjects) {
   EXPECT_EQ(yours_iter->first, "yours");
   EXPECT_EQ(yours_iter->second.name, "your object");
 
-  EXPECT_EQ(&**objects.some_object, &yours_iter->second);
+  EXPECT_EQ(&*objects.some_object, &yours_iter->second);
 
   EXPECT_EQ(objects.object_numbers.size(), 2);
   const freeisle::def::RefMap<Object, uint32_t>::iterator mine_number_iter =
@@ -212,7 +212,7 @@ TEST(CollectionLoader, TwoObjectsDelayLoad) {
   EXPECT_EQ(yours_iter->first, "yours");
   EXPECT_EQ(yours_iter->second.name, "your object");
 
-  EXPECT_EQ(&**objects.some_object, &yours_iter->second);
+  EXPECT_EQ(&*objects.some_object, &yours_iter->second);
 
   EXPECT_EQ(objects.object_numbers.size(), 2);
   const freeisle::def::RefMap<Object, uint32_t>::iterator mine_number_iter =

--- a/src/engine/state/Shop.hh
+++ b/src/engine/state/Shop.hh
@@ -11,13 +11,6 @@ namespace freeisle::state {
  * Shop stores the state of a shope in the game.
  */
 struct Shop {
-  // not copyable due to references to other objects
-  Shop(const Shop &) = delete;
-  Shop(Shop &&) = delete;
-
-  Shop &operator=(const Shop &) = delete;
-  Shop &operator=(Shop &&) = delete;
-
   /**
    * Definition of this shop.
    */
@@ -27,7 +20,7 @@ struct Shop {
    * Player who owns the shop. The shop is generating income for this player,
    * and this player can produce units in the shop.
    */
-  def::Ref<Player> owner;
+  def::NullableRef<Player> owner;
 
   /**
    * State on which units are contained in the shop.

--- a/src/engine/state/State.hh
+++ b/src/engine/state/State.hh
@@ -13,16 +13,6 @@ namespace freeisle::state {
  * Represents the entire game state.
  */
 struct State {
-  State() = default;
-
-  // TODO(armin): implement deep copy for AI
-  State(const State &) = delete;
-  State(State &&) = default; // I think this one works out of the box; pointers
-                             // will remain valid
-
-  State &operator=(const State &) = delete;
-  State &operator=(State &&) = delete;
-
   /**
    * Scenario that is being played.
    */

--- a/src/engine/state/Unit.hh
+++ b/src/engine/state/Unit.hh
@@ -18,13 +18,13 @@ struct Unit {
    * the game, but might be interesting to look at.
    */
   struct Stats {
-    uint32_t hitsDelivered;
-    uint32_t hitsTaken;
+    uint32_t hits_delivered;
+    uint32_t hits_taken;
 
-    uint32_t damageTaken;
-    uint32_t damageCaused;
+    uint32_t damage_taken;
+    uint32_t damage_caused;
 
-    uint32_t hexesMoved;
+    uint32_t hexes_moved;
   };
 
   /**
@@ -80,12 +80,12 @@ struct Unit {
    * Whether the unit has performed an action (attack or supply) during
    * this turn.
    */
-  bool hasActioned;
+  bool has_actioned;
 
   /**
    * Whether the unit has soared (changed level) during this turn.
    */
-  bool hasSoared;
+  bool has_soared;
 
   /**
    * Supplies that this unit has left to supply other units with.
@@ -106,12 +106,12 @@ struct Unit {
   /**
    * Pointer to the unit that is transporting this unit, if any.
    */
-  def::NullableRef<Unit> containedInUnit;
+  def::NullableRef<Unit> contained_in_unit;
 
   /**
    * Pointer to the shop that this unit is inside, if any.
    */
-  def::NullableRef<Shop> containedInShop;
+  def::NullableRef<Shop> contained_in_shop;
 };
 
 } // namespace freeisle::state

--- a/src/engine/state/serialize/PlayerHandlers.cc
+++ b/src/engine/state/serialize/PlayerHandlers.cc
@@ -82,8 +82,7 @@ void PlayerLoader::load(json::loader::Context &ctx, Json::Value &value) {
   player_->wealth = json::loader::load<uint32_t>(ctx, value, "wealth");
   player_->captain = def::serialize::load_ref(ctx, value, "captain", units_);
   if (player_->captain) {
-    const def::Ref<state::Unit> captain = *player_->captain;
-    if (!captain->owner || &**captain->owner != player_) {
+    if (!player_->captain->owner || &*player_->captain->owner != player_) {
       throw json::loader::Error::create(
           ctx, "captain", value["captain"],
           "Unit declared has captain has different owner");
@@ -97,7 +96,7 @@ void PlayerLoader::load(json::loader::Context &ctx, Json::Value &value) {
 
   for (def::Collection<Unit>::iterator iter = units_.begin();
        iter != units_.end(); ++iter) {
-    if (iter->second.owner && &**iter->second.owner == player_) {
+    if (iter->second.owner && &*iter->second.owner == player_) {
       player_->units.insert(iter);
     }
   }

--- a/src/engine/state/serialize/test/TestPlayerHandlers.cc
+++ b/src/engine/state/serialize/test/TestPlayerHandlers.cc
@@ -84,7 +84,7 @@ TEST_F(TestPlayerHandlers, LoadPlayer) {
   EXPECT_EQ(player->color.g, 50);
   EXPECT_EQ(player->color.b, 10);
   ASSERT_TRUE(player->team);
-  EXPECT_EQ(&**player->team, &teams["south"]);
+  EXPECT_EQ(&*player->team, &teams["south"]);
   ASSERT_EQ(player->fow.width(), 5);
   ASSERT_EQ(player->fow.height(), 5);
 
@@ -96,7 +96,7 @@ TEST_F(TestPlayerHandlers, LoadPlayer) {
 
   EXPECT_EQ(player->wealth, 1000);
   ASSERT_TRUE(player->captain);
-  EXPECT_EQ(&**player->captain, &units["unit003"]);
+  EXPECT_EQ(&*player->captain, &units["unit003"]);
   EXPECT_EQ(player->lose_conditions,
             freeisle::core::Bitmask<freeisle::def::Goal>(
                 freeisle::def::Goal::ConquerHq,


### PR DESCRIPTION
Instead of being a std::optional, make it a thin wrapper around
std::optional. This way, to get to the actual value, a single dereference
is enough and one doesn't need to use awkward constructs such as `&**ref`.