### PR TITLE
Allow non-const dereferincing of def::Ref

### DIFF
--- a/src/engine/def/Collection.hh
+++ b/src/engine/def/Collection.hh
@@ -15,7 +15,9 @@ namespace freeisle::def {
 template <typename T> using Collection = std::map<std::string, T>;
 
 /**
- * A reference to an object in a collection.
+ * A reference to an object in a collection. It can only be copied from
+ * non-const reference for const correctness. Use a Ref<const T> if you have
+ * a const Ref and need to make a copy.
  */
 template <typename T> class Ref {
 public:
@@ -83,6 +85,35 @@ public:
 
 private:
   typename Collection<T>::iterator iter;
+};
+
+/**
+ * Same as a Ref<T>, but only provides const access to the underlying
+ * object.
+ */
+template <typename T> class Ref<const T> {
+public:
+  Ref(typename Collection<T>::const_iterator iter) : iter(iter) {}
+
+  /**
+   * Return the object ID of the referred object.
+   */
+  const std::string &id() const { return iter->first; }
+
+  const T &operator*() const { return iter->second; }
+  const T *operator->() const { return &iter->second; }
+
+  /**
+   * Augment this reference to a non-const ref. This needs a non-const
+   * collection.
+   */
+  Ref<T> augment(Collection<T> &collection) {
+    assert(collection.find(iter->first) == iter);
+    return collection.find(iter->first);
+  }
+
+private:
+  typename Collection<T>::const_iterator iter;
 };
 
 /**

--- a/src/engine/def/Collection.hh
+++ b/src/engine/def/Collection.hh
@@ -24,23 +24,29 @@ public:
    */
   Ref(typename Collection<T>::iterator iter) : iter(iter) {}
 
+  Ref(Ref &other) noexcept : iter(other.iter) {}
+  Ref(Ref &&other) noexcept : iter(other.iter) {}
+  Ref(const Ref &) = delete;
+
+  Ref &operator=(Ref<T> &other) noexcept {
+    iter = other.iter;
+    return *this;
+  }
+  Ref &operator=(Ref<T> &&other) noexcept {
+    iter = other.iter;
+    return *this;
+  }
+  Ref &operator=(const Ref<T> &) = delete;
+
   /**
    * Return the object ID of the referred object.
    */
   const std::string &id() const { return iter->first; }
 
+  T &operator*() { return iter->second; }
   const T &operator*() const { return iter->second; }
+  T *operator->() { return &iter->second; }
   const T *operator->() const { return &iter->second; }
-
-  /**
-   * Return a non-const reference to the referenced object. This is only
-   * safe if the caller can provide a reference to the (non-const) collection
-   * containing the referenced object.
-   */
-  T &get(Collection<T> &collection) {
-    assert(collection.find(iter->first) == iter);
-    return iter->second;
-  }
 
   /**
    * Compare to other references. A reference compares less than another
@@ -85,9 +91,9 @@ private:
  */
 template <typename T> class NullableRef {
 public:
-  NullableRef() = default;
-  NullableRef(typename Collection<T>::iterator iter) : ref_(iter) {}
-  NullableRef(Ref<T> ref) : ref_(ref) {}
+  NullableRef() noexcept = default;
+  NullableRef(typename Collection<T>::iterator iter) noexcept : ref_(iter) {}
+  NullableRef(Ref<T> ref) noexcept : ref_(std::move(ref)) {}
 
   /**
    * Returns whether the NullableRef points to a valid object or not.
@@ -142,5 +148,29 @@ using RefMap = std::map<Ref<C>, T, typename Ref<C>::Compare>;
  * collection.
  */
 template <typename T> using RefSet = std::set<Ref<T>, typename Ref<T>::Compare>;
+
+/**
+ * Create a collection from a fixed number of pairs. This can be used instead
+ * of construction with an initializer list if the type T is not
+ * copy-constructible.
+ */
+template <typename T, typename... Args>
+Collection<T> make_collection(Args &&... args) {
+  Collection<T> collection;
+  (collection.insert(std::forward<Args>(args)), ...);
+  return collection;
+}
+
+/**
+ * Create a refset from a fixed number of elements T. This can be used
+ * instead of construction with an initilalizer list if the type T is not
+ * copy-constructible.
+ */
+template <typename T, typename... Args>
+RefSet<T> make_ref_set(Args &&... args) {
+  RefSet<T> set;
+  (set.insert(std::forward<Args>(args)), ...);
+  return set;
+}
 
 } // namespace freeisle::def

--- a/src/engine/def/serialize/CollectionLoaders.hh
+++ b/src/engine/def/serialize/CollectionLoaders.hh
@@ -37,7 +37,7 @@ public:
           collection_->try_emplace(key);
       assert(result.second);
 
-      child_handler_.set(result.first->second);
+      child_handler_.set(result.first);
       json::loader::load_object(ctx, value, key.c_str(), child_handler_);
     }
   }
@@ -54,7 +54,7 @@ private:
  */
 template <typename T> class EmptyChildHandler {
 public:
-  void set(T &obj) {}
+  void set(def::Ref<T> obj) {}
   void load(json::loader::Context &ctx, Json::Value &value) {}
 };
 
@@ -81,7 +81,7 @@ public:
   void load(json::loader::Context &ctx, Json::Value &value) {
     for (typename def::Collection<T>::iterator iter = collection_->begin();
          iter != collection_->end(); ++iter) {
-      child_handler_.set(iter->second);
+      child_handler_.set(iter);
       json::loader::load_object(ctx, value, iter->first.c_str(),
                                 child_handler_);
     }

--- a/src/engine/def/serialize/CollectionSavers.hh
+++ b/src/engine/def/serialize/CollectionSavers.hh
@@ -33,7 +33,7 @@ public:
     for (typename def::Collection<T>::const_iterator iter =
              collection_->begin();
          iter != collection_->end(); ++iter) {
-      child_handler_.set(iter->second);
+      child_handler_.set(iter);
       json::saver::save_object(ctx, value, iter->first.c_str(), child_handler_);
     }
   }

--- a/src/engine/def/serialize/MapDefHandlers.cc
+++ b/src/engine/def/serialize/MapDefHandlers.cc
@@ -15,7 +15,7 @@ DecorationDefLoader::DecorationDefLoader(
     std::map<uint32_t, const def::DecorationDef *> &indices)
     : def_(nullptr), indices(indices) {}
 
-void DecorationDefLoader::set(def::DecorationDef &def) { def_ = &def; }
+void DecorationDefLoader::set(def::Ref<DecorationDef> def) { def_ = &*def; }
 
 void DecorationDefLoader::load(json::loader::Context &ctx, Json::Value &value) {
   def_->name = json::loader::load<std::string>(ctx, value, "name");
@@ -44,7 +44,9 @@ DecorationDefSaver::DecorationDefSaver(
     std::map<const def::DecorationDef *, uint32_t> &reverse_index_map)
     : def_(nullptr), index_(0), reverse_index_map_(reverse_index_map) {}
 
-void DecorationDefSaver::set(const def::DecorationDef &def) { def_ = &def; }
+void DecorationDefSaver::set(def::Ref<const def::DecorationDef> def) {
+  def_ = &*def;
+}
 
 void DecorationDefSaver::save(json::saver::Context &ctx, Json::Value &value) {
   json::saver::save(ctx, value, "name", def_->name);

--- a/src/engine/def/serialize/MapDefHandlers.hh
+++ b/src/engine/def/serialize/MapDefHandlers.hh
@@ -14,7 +14,7 @@ class DecorationDefLoader {
 public:
   DecorationDefLoader(std::map<uint32_t, const def::DecorationDef *> &indices);
 
-  void set(def::DecorationDef &def);
+  void set(def::Ref<def::DecorationDef> def);
   void load(json::loader::Context &ctx, Json::Value &value);
 
 private:
@@ -27,7 +27,7 @@ public:
   DecorationDefSaver(
       std::map<const def::DecorationDef *, uint32_t> &reverse_index_map);
 
-  void set(const def::DecorationDef &def);
+  void set(def::Ref<const def::DecorationDef> def);
   void save(json::saver::Context &ctx, Json::Value &value);
 
 private:

--- a/src/engine/def/serialize/ShopDefHandlers.cc
+++ b/src/engine/def/serialize/ShopDefHandlers.cc
@@ -35,7 +35,7 @@ ShopDefLoader::ShopDefLoader(const def::MapDef &map,
                              AuxData &aux)
     : shop_(nullptr), map_(map), unit_defs_(unit_defs), aux_(aux) {}
 
-void ShopDefLoader::set(def::ShopDef &shop) { shop_ = &shop; }
+void ShopDefLoader::set(def::Ref<def::ShopDef> shop) { shop_ = &*shop; }
 
 void ShopDefLoader::load(json::loader::Context &ctx, Json::Value &value) {
   assert(shop_ != nullptr);
@@ -56,7 +56,7 @@ ShopDefSaver::ShopDefSaver(const def::Collection<def::UnitDef> &unit_defs,
                            AuxData &aux)
     : shop_(nullptr), unit_defs_(unit_defs), aux_(aux) {}
 
-void ShopDefSaver::set(const def::ShopDef &shop) { shop_ = &shop; }
+void ShopDefSaver::set(def::Ref<const def::ShopDef> shop) { shop_ = &*shop; }
 
 void ShopDefSaver::save(json::saver::Context &ctx, Json::Value &value) {
   assert(shop_ != nullptr);

--- a/src/engine/def/serialize/ShopDefHandlers.hh
+++ b/src/engine/def/serialize/ShopDefHandlers.hh
@@ -37,7 +37,7 @@ public:
   ShopDefLoader(const def::MapDef &map,
                 def::Collection<def::UnitDef> &unit_defs, AuxData &aux);
 
-  void set(def::ShopDef &shop);
+  void set(def::Ref<def::ShopDef> shop);
   void load(json::loader::Context &ctx, Json::Value &value);
 
 private:
@@ -51,7 +51,7 @@ class ShopDefSaver {
 public:
   ShopDefSaver(const def::Collection<def::UnitDef> &unit_defs, AuxData &aux);
 
-  void set(const def::ShopDef &shop);
+  void set(def::Ref<const def::ShopDef> shop);
   void save(json::saver::Context &ctx, Json::Value &value);
 
 private:

--- a/src/engine/def/serialize/UnitDefHandlers.hh
+++ b/src/engine/def/serialize/UnitDefHandlers.hh
@@ -54,7 +54,7 @@ class WeaponDefLoader {
 public:
   WeaponDefLoader() : weapon_(nullptr) {}
 
-  void set(def::WeaponDef &def) { weapon_ = &def; }
+  void set(def::Ref<def::WeaponDef> def) { weapon_ = &*def; }
   void load(json::loader::Context &ctx, Json::Value &value);
 
 private:
@@ -65,7 +65,7 @@ class WeaponDefSaver {
 public:
   WeaponDefSaver() : weapon_(nullptr) {}
 
-  void set(const def::WeaponDef &def) { weapon_ = &def; }
+  void set(def::Ref<const def::WeaponDef> def) { weapon_ = &*def; }
   void save(json::saver::Context &ctx, Json::Value &value);
 
 private:
@@ -76,7 +76,7 @@ class UnitDefLoader {
 public:
   UnitDefLoader(AuxData &aux) : aux_(aux), unit_(nullptr) {}
 
-  void set(def::UnitDef &unit) { unit_ = &unit; }
+  void set(def::Ref<def::UnitDef> unit) { unit_ = &*unit; }
   void load(json::loader::Context &ctx, Json::Value &value);
 
 private:
@@ -88,7 +88,7 @@ class UnitDefSaver {
 public:
   UnitDefSaver(AuxData &aux) : aux_(aux), unit_(nullptr) {}
 
-  void set(const def::UnitDef &unit) { unit_ = &unit; }
+  void set(def::Ref<const def::UnitDef> unit) { unit_ = &*unit; }
   void save(json::saver::Context &ctx, Json::Value &value);
 
 private:

--- a/src/engine/def/serialize/test/TestCollectionSavers.cc
+++ b/src/engine/def/serialize/test/TestCollectionSavers.cc
@@ -26,7 +26,7 @@ struct Objects {
 struct ObjectHandler {
   const Object *obj;
 
-  void set(const Object &o) { obj = &o; }
+  void set(freeisle::def::Ref<const Object> o) { obj = &*o; }
 
   void save(freeisle::json::saver::Context &ctx, Json::Value &value) {
     freeisle::json::saver::save(ctx, value, "name", obj->name);

--- a/src/engine/def/serialize/test/TestScenarioHandlers.cc
+++ b/src/engine/def/serialize/test/TestScenarioHandlers.cc
@@ -43,7 +43,8 @@ TEST_F(TestScenarioHandlers, Save) {
                   {{"obj001", freeisle::def::DecorationDef{.name = "flowers"}}},
               .grid = freeisle::core::Grid<freeisle::def::MapDef::Hex>(5, 5)},
       .units = {{"grunt", freeisle::def::UnitDef{}}},
-      .shops = {{"fayetteville", freeisle::def::ShopDef{}}}};
+      .shops = freeisle::def::make_collection<freeisle::def::ShopDef>(
+          std::make_pair("fayetteville", freeisle::def::ShopDef{}))};
 
   const std::map<std::string, freeisle::json::IncludeInfo> include_map = {
       {".units.grunt",

--- a/src/engine/def/serialize/test/TestShopDefHandlers.cc
+++ b/src/engine/def/serialize/test/TestShopDefHandlers.cc
@@ -30,9 +30,10 @@ TEST_F(TestShopDefHandlers, Load) {
       unit_defs.find("grunt");
   ASSERT_NE(grunt, unit_defs.end());
 
-  freeisle::def::ShopDef shop;
+  freeisle::def::Collection<freeisle::def::ShopDef> shops;
+  freeisle::def::ShopDef &shop = shops["shop001"];
   freeisle::def::serialize::ShopDefLoader loader(map, unit_defs, aux);
-  loader.set(shop);
+  loader.set(shops.find("shop001"));
 
   freeisle::json::loader::load_root_object("data/shop_fayetteville.json",
                                            loader);
@@ -63,9 +64,11 @@ TEST_F(TestShopDefHandlers, LoadInvalidLocation) {
       unit_defs.find("grunt");
   ASSERT_NE(grunt, unit_defs.end());
 
-  freeisle::def::ShopDef shop;
+  freeisle::def::Collection<freeisle::def::ShopDef> shops;
+  shops.try_emplace("shop001");
+
   freeisle::def::serialize::ShopDefLoader loader(map, unit_defs, aux);
-  loader.set(shop);
+  loader.set(shops.find("shop001"));
 
   ASSERT_THROW_KEEP_AS_E(freeisle::json::loader::load_root_object(
                              "data/shop_fayetteville.json", loader),
@@ -88,19 +91,22 @@ TEST_F(TestShopDefHandlers, Save) {
       unit_defs.find("grunt");
   ASSERT_NE(grunt, unit_defs.end());
 
-  const freeisle::def::ShopDef shop{
-      .name = "Fayetteville",
-      .type = freeisle::def::ShopDef::Type::Town,
-      .income = 350,
-      .container = {.max_units = 4,
-                    .max_weight = 4000,
-                    .supported_levels = freeisle::def::Level::Land},
-      .production_list =
-          freeisle::def::make_ref_set<freeisle::def::UnitDef>(grunt),
-      .location = {.x = 4, .y = 3}};
+  const freeisle::def::Collection<freeisle::def::ShopDef> shop_defs =
+      freeisle::def::make_collection<freeisle::def::ShopDef>(std::make_pair(
+          "shop001",
+          freeisle::def::ShopDef{
+              .name = "Fayetteville",
+              .type = freeisle::def::ShopDef::Type::Town,
+              .income = 350,
+              .container = {.max_units = 4,
+                            .max_weight = 4000,
+                            .supported_levels = freeisle::def::Level::Land},
+              .production_list =
+                  freeisle::def::make_ref_set<freeisle::def::UnitDef>(grunt),
+              .location = {.x = 4, .y = 3}}));
 
   freeisle::def::serialize::ShopDefSaver saver(unit_defs, aux);
-  saver.set(shop);
+  saver.set(shop_defs.find("shop001"));
 
   const std::vector<uint8_t> result =
       freeisle::json::saver::save_root_object(saver, nullptr);

--- a/src/engine/def/serialize/test/TestShopDefHandlers.cc
+++ b/src/engine/def/serialize/test/TestShopDefHandlers.cc
@@ -95,7 +95,8 @@ TEST_F(TestShopDefHandlers, Save) {
       .container = {.max_units = 4,
                     .max_weight = 4000,
                     .supported_levels = freeisle::def::Level::Land},
-      .production_list = {grunt},
+      .production_list =
+          freeisle::def::make_ref_set<freeisle::def::UnitDef>(grunt),
       .location = {.x = 4, .y = 3}};
 
   freeisle::def::serialize::ShopDefSaver saver(unit_defs, aux);

--- a/src/engine/def/serialize/test/TestUnitDefHandlers.cc
+++ b/src/engine/def/serialize/test/TestUnitDefHandlers.cc
@@ -19,9 +19,10 @@ public:
 };
 
 TEST_F(TestUnitDefHandlers, Load) {
-  freeisle::def::UnitDef unit;
+  freeisle::def::Collection<freeisle::def::UnitDef> units;
+  freeisle::def::UnitDef &unit = units["unit001"];
   freeisle::def::serialize::UnitDefLoader loader(aux);
-  loader.set(unit);
+  loader.set(units.find("unit001"));
   freeisle::json::loader::load_root_object("data/unit_grunt.json", loader);
 
   EXPECT_EQ(unit.name, "grunt");
@@ -111,7 +112,6 @@ TEST_F(TestUnitDefHandlers, Save) {
   unit.movement_cost[freeisle::def::BaseTerrainType::Mountain] = 300;
   unit.movement_cost[freeisle::def::OverlayTerrainType::Forest] = 150;
   unit.movement_cost[freeisle::def::OverlayTerrainType::Road] = 90;
-  ;
   unit.movement_cost[freeisle::def::OverlayTerrainType::Crevice] = 250;
   unit.movement_cost[freeisle::def::OverlayTerrainType::Fortification] = 100;
   unit.protection[freeisle::def::BaseTerrainType::Grass] = 100;
@@ -152,8 +152,11 @@ TEST_F(TestUnitDefHandlers, Save) {
   unit.view_range = 4;
   unit.jamming_range = 1;
 
+  const freeisle::def::Collection<freeisle::def::UnitDef> units = {
+      {"unit001", unit}};
+
   freeisle::def::serialize::UnitDefSaver saver(aux);
-  saver.set(unit);
+  saver.set(units.find("unit001"));
 
   const std::vector<uint8_t> result =
       freeisle::json::saver::save_root_object(saver, nullptr);

--- a/src/engine/state/Map.hh
+++ b/src/engine/state/Map.hh
@@ -1,6 +1,11 @@
 #pragma once
 
-#include "collection/Ref.hh"
+#include "def/Collection.hh"
+#include "def/MapDef.hh"
+
+#include "state/Unit.hh"
+
+#include "core/Grid.hh"
 
 namespace freeisle::state {
 
@@ -36,7 +41,7 @@ struct Map {
   /**
    * Grid with information for all hex tiles.
    */
-  Grid<Hex> grid;
+  core::Grid<Hex> grid;
 };
 
 } // namespace freeisle::state

--- a/src/engine/state/serialize/test/TestPlayerHandlers.cc
+++ b/src/engine/state/serialize/test/TestPlayerHandlers.cc
@@ -60,11 +60,11 @@ TEST_F(TestPlayerHandlers, LoadPlayer) {
 
   freeisle::def::Ref<freeisle::state::Player> player = players.begin();
 
-  freeisle::def::Collection<freeisle::state::Unit> units = {
-      {"unit001", freeisle::state::Unit{.owner = player}},
-      {"unit002", freeisle::state::Unit{}},
-      {"unit003", freeisle::state::Unit{.owner = player}},
-  };
+  freeisle::def::Collection<freeisle::state::Unit> units =
+      freeisle::def::make_collection<freeisle::state::Unit>(
+          std::make_pair("unit001", freeisle::state::Unit{.owner = player}),
+          std::make_pair("unit002", freeisle::state::Unit{}),
+          std::make_pair("unit003", freeisle::state::Unit{.owner = player}));
 
   freeisle::def::Collection<freeisle::state::Team> teams = {
       {"north", freeisle::state::Team{.name = "North"}},
@@ -72,7 +72,7 @@ TEST_F(TestPlayerHandlers, LoadPlayer) {
   };
 
   freeisle::state::serialize::PlayerLoader loader(map, teams, units, aux);
-  loader.set(player.get(players));
+  loader.set(*player);
 
   freeisle::json::loader::load_root_object(
       freeisle::fs::path::join(orig_directory, "data", "player_rose.json")
@@ -117,11 +117,11 @@ TEST_F(TestPlayerHandlers, LoadPlayerTooLargeGridSize) {
 
   freeisle::def::Ref<freeisle::state::Player> player = players.begin();
 
-  freeisle::def::Collection<freeisle::state::Unit> units = {
-      {"unit001", freeisle::state::Unit{.owner = player}},
-      {"unit002", freeisle::state::Unit{}},
-      {"unit003", freeisle::state::Unit{.owner = player}},
-  };
+  freeisle::def::Collection<freeisle::state::Unit> units =
+      freeisle::def::make_collection<freeisle::state::Unit>(
+          std::make_pair("unit001", freeisle::state::Unit{.owner = player}),
+          std::make_pair("unit002", freeisle::state::Unit{}),
+          std::make_pair("unit003", freeisle::state::Unit{.owner = player}));
 
   freeisle::def::Collection<freeisle::state::Team> teams = {
       {"north", freeisle::state::Team{.name = "North"}},
@@ -129,7 +129,7 @@ TEST_F(TestPlayerHandlers, LoadPlayerTooLargeGridSize) {
   };
 
   freeisle::state::serialize::PlayerLoader loader(map, teams, units, aux);
-  loader.set(player.get(players));
+  loader.set(*player);
 
   ASSERT_THROW_KEEP_AS_E(
       freeisle::json::loader::load_root_object(
@@ -154,11 +154,11 @@ TEST_F(TestPlayerHandlers, LoadPlayerTooSmallGridSize) {
 
   freeisle::def::Ref<freeisle::state::Player> player = players.begin();
 
-  freeisle::def::Collection<freeisle::state::Unit> units = {
-      {"unit001", freeisle::state::Unit{.owner = player}},
-      {"unit002", freeisle::state::Unit{}},
-      {"unit003", freeisle::state::Unit{.owner = player}},
-  };
+  freeisle::def::Collection<freeisle::state::Unit> units =
+      freeisle::def::make_collection<freeisle::state::Unit>(
+          std::make_pair("unit001", freeisle::state::Unit{.owner = player}),
+          std::make_pair("unit002", freeisle::state::Unit{}),
+          std::make_pair("unit003", freeisle::state::Unit{.owner = player}));
 
   freeisle::def::Collection<freeisle::state::Team> teams = {
       {"north", freeisle::state::Team{.name = "North"}},
@@ -166,7 +166,7 @@ TEST_F(TestPlayerHandlers, LoadPlayerTooSmallGridSize) {
   };
 
   freeisle::state::serialize::PlayerLoader loader(map, teams, units, aux);
-  loader.set(player.get(players));
+  loader.set(*player);
 
   ASSERT_THROW_KEEP_AS_E(
       freeisle::json::loader::load_root_object(
@@ -191,11 +191,11 @@ TEST_F(TestPlayerHandlers, LoadPlayerCaptainUnowned) {
 
   freeisle::def::Ref<freeisle::state::Player> player = players.begin();
 
-  freeisle::def::Collection<freeisle::state::Unit> units = {
-      {"unit001", freeisle::state::Unit{.owner = player}},
-      {"unit002", freeisle::state::Unit{}},
-      {"unit003", freeisle::state::Unit{}},
-  };
+  freeisle::def::Collection<freeisle::state::Unit> units =
+      freeisle::def::make_collection<freeisle::state::Unit>(
+          std::make_pair("unit001", freeisle::state::Unit{.owner = player}),
+          std::make_pair("unit002", freeisle::state::Unit{}),
+          std::make_pair("unit003", freeisle::state::Unit{}));
 
   freeisle::def::Collection<freeisle::state::Team> teams = {
       {"north", freeisle::state::Team{.name = "North"}},
@@ -203,7 +203,7 @@ TEST_F(TestPlayerHandlers, LoadPlayerCaptainUnowned) {
   };
 
   freeisle::state::serialize::PlayerLoader loader(map, teams, units, aux);
-  loader.set(player.get(players));
+  loader.set(*player);
 
   ASSERT_THROW_KEEP_AS_E(
       freeisle::json::loader::load_root_object(
@@ -228,11 +228,12 @@ TEST_F(TestPlayerHandlers, LoadPlayerCaptainOtherPlayer) {
 
   freeisle::def::Ref<freeisle::state::Player> player = players.begin();
 
-  freeisle::def::Collection<freeisle::state::Unit> units = {
-      {"unit001", freeisle::state::Unit{.owner = player}},
-      {"unit002", freeisle::state::Unit{}},
-      {"unit003", freeisle::state::Unit{.owner = players.find("player2")}},
-  };
+  freeisle::def::Collection<freeisle::state::Unit> units =
+      freeisle::def::make_collection<freeisle::state::Unit>(
+          std::make_pair("unit001", freeisle::state::Unit{.owner = player}),
+          std::make_pair("unit002", freeisle::state::Unit{}),
+          std::make_pair("unit003", freeisle::state::Unit{
+                                        .owner = players.find("player2")}));
 
   freeisle::def::Collection<freeisle::state::Team> teams = {
       {"north", freeisle::state::Team{.name = "North"}},
@@ -240,7 +241,7 @@ TEST_F(TestPlayerHandlers, LoadPlayerCaptainOtherPlayer) {
   };
 
   freeisle::state::serialize::PlayerLoader loader(map, teams, units, aux);
-  loader.set(player.get(players));
+  loader.set(*player);
 
   ASSERT_THROW_KEEP_AS_E(
       freeisle::json::loader::load_root_object(
@@ -264,11 +265,11 @@ TEST_F(TestPlayerHandlers, SavePlayer) {
 
   freeisle::def::Ref<freeisle::state::Player> player = players.begin();
 
-  freeisle::def::Collection<freeisle::state::Unit> units = {
-      {"unit001", freeisle::state::Unit{.owner = player}},
-      {"unit002", freeisle::state::Unit{}},
-      {"unit003", freeisle::state::Unit{.owner = player}},
-  };
+  freeisle::def::Collection<freeisle::state::Unit> units =
+      freeisle::def::make_collection<freeisle::state::Unit>(
+          std::make_pair("unit001", freeisle::state::Unit{.owner = player}),
+          std::make_pair("unit002", freeisle::state::Unit{}),
+          std::make_pair("unit003", freeisle::state::Unit{.owner = player}));
 
   freeisle::def::Collection<freeisle::state::Team> teams = {
       {"north", freeisle::state::Team{.name = "North"}},
@@ -278,7 +279,7 @@ TEST_F(TestPlayerHandlers, SavePlayer) {
   freeisle::core::Grid<freeisle::state::Player::Fow> grid(5, 5);
   grid(4, 0).discovered = true;
 
-  player.get(players) = freeisle::state::Player{
+  *player = freeisle::state::Player{
       .name = "Rose",
       .color =
           {
@@ -293,7 +294,8 @@ TEST_F(TestPlayerHandlers, SavePlayer) {
       .lose_conditions = {freeisle::def::Goal::ConquerHq,
                           freeisle::def::Goal::EliminateCaptain},
       .is_eliminated = false,
-      .units = {units.find("unit001"), units.find("unit003")},
+      .units = freeisle::def::make_ref_set<freeisle::state::Unit>(
+          units.find("unit001"), units.find("unit003")),
   };
 
   freeisle::state::serialize::PlayerSaver saver(map, teams, units, aux);


### PR DESCRIPTION
Instead, make it non-copyable, so that one cannot get a non-const Ref from
a const Ref. This makes the Refs a bit easier to use, but one needs to be
a bit more careful when passing them around; in particular they cannot be
part of initializer lists anymore.

Then, have CollectionLoader and CollectionSaver pass def::Ref instead of a normal reference
to the child handler. Then the child handler has access to the object ID and the ref in case
it needs to be read or set somewhere.